### PR TITLE
Remove Visual Studio Code from IDE

### DIFF
--- a/1-js/01-getting-started/2-code-editors/article.md
+++ b/1-js/01-getting-started/2-code-editors/article.md
@@ -13,12 +13,11 @@ An IDE loads the project (can be many files), allows navigation between files, p
 If you haven't considered selecting an IDE yet, look at the following variants:
 
 - [WebStorm](http://www.jetbrains.com/webstorm/) for frontend development and other editors of the same company if you need additional languages (paid).
-- [Visual Studio Code](https://code.visualstudio.com/) (free).
 - [Netbeans](http://netbeans.org/) (paid).
 
 All of the IDEs except cross-platform.
 
-For Windows, there's also a "Visual Studio" editor, don't mess it with "Visual Studio Code". "Visual Studio" is a paid and actually very powerful Windows-only editor, well-suited for .NET platform. A free version of it is called ([Visual Studio Community](https://www.visualstudio.com/vs/community/)).
+For Windows, there's also a "[Visual Studio](https://visualstudio.microsoft.com/)" IDE, don't mess it with "Visual Studio Code". "Visual Studio" is a paid and actually very powerful Windows-only editor, well-suited for .NET platform. A free version of it is called ([Visual Studio Community](https://www.visualstudio.com/vs/community/)).
 
 Many IDEs are paid, but have a trial period. Their cost is usually negligible compared to a qualified developer's salary, so just choose the best one for you.
 


### PR DESCRIPTION
Hello, 

I disagree to call Visual Studio Code as an IDE. As i understand IDE versus text editor and as i have listened around me, VSCode is just a very good text editor, with many good plugins, like Atom, Sublime Text or Brackets.

According me, there are all text editor. IDE are Visual Studio, PHPStorm, Xcode...

We can speak about how change this text, I briefly change it.

Regards, 