### PR TITLE
Minor grammatical typo fix

### DIFF
--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -551,7 +551,7 @@ This method actually has two additional arguments specified in [the documentatio
 ## Internals, Unicode
 
 ```warn header="Advanced knowledge"
-The section goes deeper into string internals. This knowledge will be useful for you if you plan to deal with emoji, rare mathematical of hieroglyphs characters or other rare symbols.
+The section goes deeper into string internals. This knowledge will be useful for you if you plan to deal with emoji, rare mathematical or hieroglyphic characters or other rare symbols.
 
 You can skip the section if you don't plan to support them.
 ```


### PR DESCRIPTION
Saying "rare mathematical __or hieroglyphic__ characters" makes a little more sense than "rare mathematical __of hieroglyphs__ characters".