### PR TITLE
Update arguments order of `then` in Part 1, 11.6 Promisification

### DIFF
--- a/1-js/11-async/06-promisify/article.md
+++ b/1-js/11-async/06-promisify/article.md
@@ -102,7 +102,7 @@ function promisify(f, manyArgs = false) {
 
 // usage:
 f = promisify(f, true);
-f(...).then(err => ..., arrayOfResults => ...)
+f(...).then(arrayOfResults => ..., err => ...)
 ```
 
 In some cases, `err` may be absent at all: `callback(result)`, or there's something exotic in the callback format, then we can promisify such functions manually.


### PR DESCRIPTION
The first argument should be for handling a successful result, and the second for error.