### PR TITLE
Let's avoid ninja_code patterns

### DIFF
--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -534,10 +534,10 @@ Luckily, all modern browsers (IE10- requires the additional library [Intl.JS](ht
 
 It provides a special method to compare strings in different languages, following their rules.
 
-The call [str.localeCompare(str2)](mdn:js/String/localeCompare):
+The call [str.localeCompare(other_string)](mdn:js/String/localeCompare):
 
-- Returns `1` if `str` is greater than `str2` according to the language rules.
-- Returns `-1` if `str` is less than `str2`.
+- Returns `1` if `str` is greater than `other_string` according to the language rules.
+- Returns `-1` if `str` is less than `other_string`.
 - Returns `0` if they are equal.
 
 For instance:


### PR DESCRIPTION
Previously, in https://javascript.info/ninja-code#soar-high-be-abstract, naming variables like `str2` is ninja code. Here's a leftover.
(The `type` name ninja-ism is not a problem here, because `string` can be seen as a description.)