### PR TITLE
Set correct prototype in User

### DIFF
--- a/1-js/04-object-basics/06-constructor-new/article.md
+++ b/1-js/04-object-basics/06-constructor-new/article.md
@@ -39,8 +39,9 @@ In other words, `new User(...)` does something like:
 function User(name) {
 *!*
   // this = {};  (implicitly)
+  // this.__proto__ = User.prototype  (implicitly)
 */!*
-
+  
   // add properties to this
   this.name = name;
   this.isAdmin = false;


### PR DESCRIPTION
Added one line of code to show modification of `this` also includes setting correct prototype. This change might prevent users from running into scenarios like below.

```
function User(name, age){
    return {
        name,
        age,
     }
}

User.prototype.display = function (){
    console.log(`${this.name} is ${this.age} years old.`)    
}

let john = new User("John", 23)

john.display()  //TypeError: john.display is not a function
// It failed because User is not a prototype of john.
```