### PR TITLE
Fix typo, so it actually does invoke the setter

### DIFF
--- a/1-js/09-classes/01-class/article.md
+++ b/1-js/09-classes/01-class/article.md
@@ -241,7 +241,7 @@ class User {
 
   constructor(name) {
     // invokes the setter
-    this._name = name;
+    this.name = name;
   }
 
 *!*


### PR DESCRIPTION
The code: `user = new User(""); // Name too short.` doesn't show an alert as intended.