### PR TITLE
adding a small clarifying comment

### DIFF
--- a/2-ui/1-document/03-dom-navigation/article.md
+++ b/2-ui/1-document/03-dom-navigation/article.md
@@ -67,7 +67,7 @@ In the DOM, the `null` value means "doesn't exist" or "no such node".
 
 There are two terms that we'll use from now on:
 
-- **Child nodes (or children)** -- elements that are direct children. In other words, they are nested exactly in the given one. For instance, `<head>` and `<body>` are children of `<html>` element.
+- **Child nodes (or children)** -- elements that are direct children (note that we refer here to Element nodes, a more specific type of nodes - more on that below). In other words, they are nested exactly in the given one. For instance, `<head>` and `<body>` are children of `<html>` element.
 - **Descendants** -- all elements that are nested in the given one, including children, their children and so on.
 
 For instance, here `<body>` has children `<div>` and `<ul>` (and few blank text nodes):


### PR DESCRIPTION
The first description of 'children' doesn't clarify clearly, in my taste that 'children' are kind of a subset of the entire child nodes of the node. Adding a small comment that states this, and refers the user to read more below).