### PR TITLE
Update article.md

### DIFF
--- a/1-js/08-prototypes/02-function-prototype/article.md
+++ b/1-js/08-prototypes/02-function-prototype/article.md
@@ -162,7 +162,7 @@ Everything is quite simple, just few notes to make things clear:
 
 - The `F.prototype` property is not the same as `[[Prototype]]`. The only thing `F.prototype` does: it sets `[[Prototype]]` of new objects when `new F()` is called.
 - The value of `F.prototype` should be either an object or null: other values won't work.
--  The `"prototype"` property only has such a special effect when is set to a constructor function, and invoked with `new`.
+-  The `"prototype"` property only has such a special effect when set on a constructor function, and invoked with `new`.
 
 On regular objects the `prototype` is nothing special:
 ```js


### PR DESCRIPTION
Original states "set TO a constructor function"; meaning that the value of "prototype" itself should be constructor function.  That's too strong; probably what was meant here is that "prototype" is merely a constructor function property.