### PR TITLE
Fix typo

### DIFF
--- a/9-regular-expressions/03-regexp-character-classes/article.md
+++ b/9-regular-expressions/03-regexp-character-classes/article.md
@@ -61,7 +61,7 @@ alert( str.match(reg) ); // CSS4
 Also we can use many character classes:
 
 ```js run
-alert( "I love HTML5!".match(/\s\w\w\w\w\d/) ); // 'HTML5'
+alert( "I love HTML5!".match(/\s\w\w\w\w\d/) ); // ' HTML5'
 ```
 
 The match (each character class corresponds to one result character):


### PR DESCRIPTION
The output when using character class `\s` except for look-behind is ` HTML5`.