### PR TITLE
Fixed code block

### DIFF
--- a/1-js/05-data-types/07-map-set-weakmap-weakset/article.md
+++ b/1-js/05-data-types/07-map-set-weakmap-weakset/article.md
@@ -92,11 +92,11 @@ alert( visitsCounts[john.id] ); // 123
 ...But `Map` is much more elegant.
 
 
-```smart header="How `Map` compares keys"
+````smart header="How `Map` compares keys"
 To test values for equivalence, `Map` uses the algorithm [SameValueZero](https://tc39.github.io/ecma262/#sec-samevaluezero). It is roughly the same as strict equality `===`, but the difference is that `NaN` is considered equal to `NaN`. So `NaN` can be used as the key as well.
 
 This algorithm can't be changed or customized.
-```
+````
 
 
 ````smart header="Chaining"


### PR DESCRIPTION
Fixed code block by adding an extra `
It was causing all text after it to be inside a code block (at least when viewing in github) for some reason.