### PR TITLE
Add stylistic and grammar fixes

### DIFF
--- a/2-ui/2-events/02-bubbling-and-capturing/article.md
+++ b/2-ui/2-events/02-bubbling-and-capturing/article.md
@@ -69,13 +69,13 @@ For instance, if we have a single handler `form.onclick`, then it can "catch" al
 In `form.onclick` handler:
 
 - `this` (`=event.currentTarget`) is the `<form>` element, because the handler runs on it.
-- `event.target` is the concrete element inside the form that actually was clicked.
+- `event.target` is the actual element inside the form that was clicked.
 
 Check it out:
 
 [codetabs height=220 src="bubble-target"]
 
-It's possible that `event.target` equals `this` -- when the click is made directly on the `<form>` element.
+It's possible that `event.target` could equal `this` -- it happens when the click is made directly on the `<form>` element.
 
 ## Stopping bubbling
 


### PR DESCRIPTION
I fixed some of the awkward phrasing:

1. `concrete` is more common in the literary style of writing and is used to denote something opposite of abstract, so placing it here when describing a relation between html elements seems unnecessarily cumbersome. Plus there's some tautology in using `concrete` together with `actually`. I propose something simpler.

2. `It’s possible that event.target equals this` -- the present indefinite tense is not quite correctly used here, because this sentence describes something that only happens conditionally and is not always true. There are many ways to rewrite this sentence, and I propose one that aims to keep the original structure of the idea.