### PR TITLE
Corrected no-declaration object destructuring

### DIFF
--- a/1-js/05-data-types/09-destructuring-assignment/article.md
+++ b/1-js/05-data-types/09-destructuring-assignment/article.md
@@ -349,7 +349,7 @@ To show JavaScript that it's not a code block, we can make it a part of an expre
 let title, width, height;
 
 // okay now
-*!*(*/!*{title, width, height}*!*)*/!* = {title: "Menu", width: 200, height: 100};
+*!*(*/!*{title, width, height} = {title: "Menu", width: 200, height: 100}*!*)*/!*;
 
 alert( title ); // Menu
 ```


### PR DESCRIPTION
Close parenthesis was in wrong location, should have been at end of the expression. Page information pertaining to this is still accurate, so the only change is the code block.

As per [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Assignment_without_declaration) info, modified to follow:
```
let a, b;
({a, b} = {a: "Apple", b:5});

alert(a); // Apple
alert(b); // 5
```