### PR TITLE
Fix the numbers in an ordered list, and move a point up.

### DIFF
--- a/1-js/09-classes/01-class/article.md
+++ b/1-js/09-classes/01-class/article.md
@@ -85,9 +85,9 @@ alert(typeof User); // function
 ```
 
 What `class User {...}` construct really does is:
-1. Creates a function named `User`, that becomes the result of the class declaration.
-    - The function code is taken from the `constructor` method (assumed empty if we don't write such method).
-3. Stores all methods, such as `sayHi`, in `User.prototype`.
+
+1. Creates a function named `User`, that becomes the result of the class declaration. The function code is taken from the `constructor` method (assumed empty if we don't write such method).
+2. Stores all methods, such as `sayHi`, in `User.prototype`.
 
 Afterwards, for new objects, when we call a method, it's taken from the prototype, just as  described in the chapter <info:function-prototype>. So a `new User` object has access to class methods.
 


### PR DESCRIPTION
I am not sure, but I guess a single point in a list doesn't make much sense. From the original:

>1. Creates a function named `User`, that becomes the result of the class declaration. 
     - The function code is taken from the `constructor` method (assumed empty if we don't write such method).
>3. Stores all methods, such as `sayHi`, in `User.prototype`.

So with this PR I suggest to "merge" it with the above numbered parent. Then I fixed the numbering, since I saw the jump from 1 to 3 in the source (the rendering is correct). Now it's 1 to 2. 

>1. Creates a function named `User`, that becomes the result of the class declaration. The function code is taken from the `constructor` method (assumed empty if we don't write such method).
>2. Stores all methods, such as `sayHi`, in `User.prototype`.

Another possibility would be to make the single unordered point, the point number 2 in the list. Then the change to number 3 would not be necessary.

>1. Creates a function named `User`, that becomes the result of the class declaration. 
>2. The function code is taken from the `constructor` method (assumed empty if we don't write such method).
>3. Stores all methods, such as `sayHi`, in `User.prototype`.