### PR TITLE
'property values' instead of 'field' in code comment

### DIFF
--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -49,7 +49,7 @@ We can add, remove and read files from it any time.
 Property values are accessible using the dot notation:
 
 ```js
-// get fields of the object:
+// get property values of the object:
 alert( user.name ); // John
 alert( user.age ); // 30
 ```


### PR DESCRIPTION
I propose this change because the term "field" was not introduced / explained in the "Objects: the basics" tutorial before.