### PR TITLE
paste negation

### DIFF
--- a/1-js/08-prototypes/01-prototype-inheritance/article.md
+++ b/1-js/08-prototypes/01-prototype-inheritance/article.md
@@ -315,7 +315,7 @@ The answer is simple: it's not enumerable. Just like all other properties of `Ob
 ```smart header="Almost all other key/value-getting methods ignore inherited properties"
 Almost all other key/value-getting methods, such as `Object.keys`, `Object.values` and so on ignore inherited properties.
 
-They only operate on the object itself. Properties from the prototype are taken into account.
+They only operate on the object itself. Properties from the prototype are *not* taken into account.
 ```
 
 ## Summary


### PR DESCRIPTION
Regardless Object.keys and other methods: 
Properties from the prototype are taken into account. -> Properties from the prototype are NOT taken into account.