### PR TITLE
Fixed spelling error

### DIFF
--- a/1-js/05-data-types/10-destructuring-assignment/article.md
+++ b/1-js/05-data-types/10-destructuring-assignment/article.md
@@ -356,7 +356,7 @@ The problem is that JavaScript treats `{...}` in the main code flow (not inside 
 }
 ```
 
-So here JavaScript assumes that we have a code block, but why there's an error. We have destructuring instead.
+So here JavaScript assumes that we have a code block, that's why there's an error. We have destructuring instead.
 
 To show JavaScript that it's not a code block, we can wrap the expression in parentheses `(...)`:
 


### PR DESCRIPTION
So here JavaScript assumes that we have a code block, but why there's an error. --> Makes no sense so replaced "but" with "that's"