### PR TITLE
Update article.md

### DIFF
--- a/1-js/04-object-basics/06-constructor-new/article.md
+++ b/1-js/04-object-basics/06-constructor-new/article.md
@@ -51,7 +51,7 @@ function User(name) {
 }
 ```
 
-So the result of `new User("Jack")` is the same object as:
+So `let user = new User("Jack")` gives the same result as:
 
 ```js
 let user = {


### PR DESCRIPTION
Says "is the same object as:", but what's below is an assignment (that includes an object). I didn't have any problem understanding it, didn't even notice it at first, but I thought it would be more accurate this way without sacrificing clarity.