### PR TITLE
Fix chapter links in "File and FileReader" lesson

### DIFF
--- a/4-binary/04-file/article.md
+++ b/4-binary/04-file/article.md
@@ -63,7 +63,7 @@ The choice of `read*` method depends on which format we prefer, how we're going 
 
 - `readAsArrayBuffer` - for binary files, to do low-level binary operations. For high-level operations, like slicing, `File` inherits from `Blob`, so we can call them directly, without reading.
 - `readAsText` - for text files, when we'd like to get a string.
-- `readAsDataURL` -- when we'd like to use this data in `src` for `img` or another tag. There's an alternative to reading a file for that, as discussed in chapter <info:blob>: `URL.createObjectURL(file)`.
+- `readAsDataURL` -- when we'd like to use this data in `src` for `img` or another tag. There's an alternative to reading a file for that, as discussed in chapter [Blob](info:blob): `URL.createObjectURL(file)`.
 
 As the reading proceeds, there are events:
 - `loadstart` -- loading started.
@@ -105,7 +105,7 @@ function readFile(input) {
 ```
 
 ```smart header="`FileReader` for blobs"
-As mentioned in the chapter <info:blob>, `FileReader` can read not just files, but any blobs.
+As mentioned in the chapter [Blob](info:blob), `FileReader` can read not just files, but any blobs.
 
 We can use it to convert a blob to another format:
 - `readAsArrayBuffer(blob)` -- to `ArrayBuffer`,


### PR DESCRIPTION
Links to the **Blob** lesson in the same chapter **Binary data, files** were in wrong/outdated markdown format.