### PR TITLE
Update solution.md

### DIFF
--- a/1-js/08-prototypes/03-native-prototypes/2-defer-to-prototype-extended/solution.md
+++ b/1-js/08-prototypes/03-native-prototypes/2-defer-to-prototype-extended/solution.md
@@ -4,7 +4,7 @@
 Function.prototype.defer = function(ms) {
   let f = this;
   return function(...args) {
-    setTimeout(() => f.apply(this, args), ms);
+    setTimeout(() => f.apply({}, args), ms);
   }
 };
 


### PR DESCRIPTION
Replace 'this' in 'apply' call with empty object. Figured it was easier to bring up issue w/ PR than as a discussion.

(Or could leave out 'apply' altogether and just have f(...args). (?))

This would be just for clarity, since, as far as I can tell, 'this' in the returned function will always be 'undefined', but having it there in the code anyway could make one wonder if if might actually have a useful value (if the new Function prototype was used with an object method). From what I've been able to discern, it would not -- it would always be 'undefined' (in strict mode, of course).

Same example I was wrong about before -- am I wrong again?

And, if I'm not, IS there a way to make the prototype wrapper work with an object method that uses 'this'?