### PR TITLE
Update article.md

### DIFF
--- a/1-js/09-classes/05-extend-natives/article.md
+++ b/1-js/09-classes/05-extend-natives/article.md
@@ -78,7 +78,7 @@ Normally, when one class extends another, both static and non-static methods are
 
 But built-in classes are an exception. They don't inherit statics from each other.
 
-For example, both `Array` and `Date` inherit from `Object`, so their instances have methods from `Object.prototype`. But `Array.[[Prototype]]` does not reference `Object`, so there's no `Array.keys()` and `Date.keys()` static methods.
+For example, both `Array` and `Date` inherit from `Object`, so their instances have methods from `Object.prototype`. But `Array.[[Prototype]]` does not reference `Object`, so there's no, for instance, `Array.keys()` (or `Date.keys()`) static method.
 
 Here's the picture structure for `Date` and `Object`:
 


### PR DESCRIPTION
and -> or, methods -> methods

I also have a question on the subject of this sentence (should this be a separate discussion entry?):
In the "Extending built-in classes" article, in the "No static inheritance in built-ins" subsection, one finds:

"But built-in classes are an exception. They don’t inherit statics from each other.

For example, both Array and Date inherit from Object, so their instances have methods from Object.prototype. But Array.[[Prototype]] does not reference Object, so there’s no Array.keys() and Date.keys() static methods."

In the "Extending built-in classes" article, in the "No static inheritance in built-ins" subsection, one finds:

"But built-in classes are an exception. They don’t inherit statics from each other.

For example, both Array and Date inherit from <code>Object</code>, so their instances have methods from <code>Object.prototype</code>. But <code>Array.[[Prototype]]</code> does not reference <code>Object</code>, so there’s no <code>Array.keys()</code> and <code>Date.keys()</code> static methods."

This is a subject of some curiosity for me. Through a little testing, I believe I have found that, in fact <code>Array.[[Prototype]]</code> DOES, however, reference <code>Function.prototype</code>, i.e. <code>Array.\_\_proto\_\_ === Function.prototype</code> (<code>true</code>). (As does <code>Date.[[Prototype]]</code>). Is there someplace where this is explained? (Preferably in a way an intelligent 11-year-old could understand?).