### PR TITLE
add test case

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/03-debounce/_js.view/test.js
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/03-debounce/_js.view/test.js
@@ -6,7 +6,16 @@ describe("debounce", function() {
   after(function() {
     this.clock.restore();
   });
-
+  
+  it("trigger the fuction execution immediately", function () {
+    let mode;
+    const f = () => mode = "leading";
+    
+    debounce(f, 1000)(); // runs without a delay
+  
+    assert.equal(mode, "leading");
+  });
+  
   it("calls the function at maximum once in ms milliseconds", function() {
     let log = '';
 


### PR DESCRIPTION
According to description of the task [debounce-decorator](https://javascript.info/call-apply-decorators#debounce-decorator) should runs immediately (leading mode), but current tests allow to pass implementations which have delay (trailing mode)