### PR TITLE
add parameter definition to arr.find()

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -268,7 +268,7 @@ alert( arr.includes(NaN) );// true (correct)
 
 Imagine we have an array of objects. How do we find an object with the specific condition?
 
-Here the [arr.find](mdn:js/Array/find) method comes in handy.
+Here the [arr.find(fn)](mdn:js/Array/find) method comes in handy.
 
 The syntax is:
 ```js


### PR DESCRIPTION
For consistency with definition of "**arr.filter(fn)**" , we need to add '**fn**' parameter to definition of **arr.find()**.