### PR TITLE
confusing about working of  reduce method

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -574,7 +574,7 @@ The calculation flow:
 
 Or in the form of a table, where each row represents a function call on the next array element:
 
-|   |`sum`|`current`|`result`|
+|   |`sum`|`current`|`sum (after arrow funtion run)`|
 |---|-----|---------|---------|
 |the first call|`0`|`1`|`1`|
 |the second call|`1`|`2`|`3`|


### PR DESCRIPTION
On the table, there is a '**result**' value for every calls of **callback arrow function**. But '**result**' variable is not defined until end of '**reduce**'  method execution. Because '**result**' variable is in left hand side of assignment operator and assignment process will be done after '**reduce**' method finished. There is a confusion because of **naming convention**.