### PR TITLE
Array type variables also support values() method

### DIFF
--- a/1-js/05-data-types/09-keys-values-entries/article.md
+++ b/1-js/05-data-types/09-keys-values-entries/article.md
@@ -11,7 +11,7 @@ They are supported for:
 
 - `Map`
 - `Set`
-- `Array` (except `arr.values()`)
+- `Array`
 
 Plain objects also support similar methods, but the syntax is a bit different.
 


### PR DESCRIPTION
**arr.values()** is supported by majority of browsers. So, maybe we need to change the exception in article.

[MDN arr.values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/values)