### PR TITLE
JSON.stringfy() output variable type consistency

### DIFF
--- a/1-js/05-data-types/12-json/article.md
+++ b/1-js/05-data-types/12-json/article.md
@@ -90,14 +90,14 @@ For instance:
 
 ```js run
 // a number in JSON is just a number
-alert( JSON.stringify(1) ) // 1
+alert( JSON.stringify(1) ) // "1"
 
 // a string in JSON is still a string, but double-quoted
 alert( JSON.stringify('test') ) // "test"
 
-alert( JSON.stringify(true) ); // true
+alert( JSON.stringify(true) ); // "true"
 
-alert( JSON.stringify([1, 2, 3]) ); // [1,2,3]
+alert( JSON.stringify([1, 2, 3]) ); // "[1,2,3]"
 ```
 
 JSON is data-only language-independent specification, so some JavaScript-specific object properties are skipped by `JSON.stringify`.


### PR DESCRIPTION
 Output variable type of **JSON.stringfy()** is **string**. So, we need to show all outputs **in quotes** to ensure consistency. alert() function shows outputs without quotes even if they are string, but this can cause misunderstanding. 