### PR TITLE
function declaration vs function call conflict

### DIFF
--- a/1-js/06-advanced-functions/03-closure/article.md
+++ b/1-js/06-advanced-functions/03-closure/article.md
@@ -351,7 +351,7 @@ Please note the additional `[[Environment]]` property is covered here. We didn't
 
     ![](lexenv-nested-makecounter-3.svg)
 
-    Please note that on this step the inner function was created, but not yet called. The code inside `function() { return count++; }` is not running.
+    Please note that on this step the inner function was created, but not yet called. The code inside `return count++;` is not running.
 
 4. As the execution goes on, the call to `makeCounter()` finishes, and the result (the tiny nested function) is assigned to the global variable `counter`:
 


### PR DESCRIPTION
`function() { return count++; }` is running because it is a **function expression**. It is running and result of this running, a function has been created and sent as a parameter to **return** command.
 `return count++;` this part is not running because the function has not been called yet.