### PR TITLE
conflict of function name and variable name

### DIFF
--- a/1-js/06-advanced-functions/03-closure/article.md
+++ b/1-js/06-advanced-functions/03-closure/article.md
@@ -565,7 +565,7 @@ function f() {
 */!*
 }
 
-let g = f(); // g is reachable, and keeps the outer lexical environment in memory
+let h = f(); // g is reachable, and keeps the outer lexical environment in memory
 ```
 
 Please note that if `f()` is called many times, and resulting functions are saved, then all corresponding Lexical Environment objects will also be retained in memory. All 3 of them in the code below:
@@ -595,10 +595,10 @@ function f() {
   return g;
 }
 
-let g = f(); // while g is alive
+let h = f(); // while g is alive
 // their corresponding Lexical Environment lives
 
-g = null; // ...and now the memory is cleaned up
+h = null; // ...and now the memory is cleaned up
 ```
 
 ### Real-life optimizations


### PR DESCRIPTION
In the snippets, firstly **g** is a name of **the nested function** and then **g** is a variable which carries address of **the nested function**. And tutorial talking about **lexical environment** of **g** and **reach-ability** of **g**, but which one of them ? Using **g** for different purpose is very bad idea. This situation is very good example of "ninja coding"!