### PR TITLE
avoid to override built-in properties

### DIFF
--- a/1-js/06-advanced-functions/05-global-object/article.md
+++ b/1-js/06-advanced-functions/05-global-object/article.md
@@ -40,9 +40,11 @@ If a value is so important that you'd like to make it available globally, write 
 ```js run
 *!*
 // make current user information global, to let all scripts access it
-window.currentUser = {
-  name: "John"
-};
+if (!window.currentUser) { //to avoid override built-in properties in window object
+  window.currentUser = {
+    name: "John"
+  };
+}
 */!*
 
 // somewhere else in code


### PR DESCRIPTION
In the snippet we aren't using **var** keyword so, it looks like **modern JS codding** standard. we block the **var** danger but there is a way to override built-in properties in window object like Math object and this is very dangerous for project. To avoid this situation we need to check for "**is property name in use**?".