### PR TITLE
code non-compatible with clarification drawing

### DIFF
--- a/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
+++ b/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
@@ -184,7 +184,7 @@ Let's compare two code fragments. The first one uses `setInterval`:
 ```js
 let i = 1;
 setInterval(function() {
-  func(i);
+  func(i++);
 }, 100);
 ```
 
@@ -198,7 +198,7 @@ setTimeout(function run() {
 }, 100);
 ```
 
-For `setInterval` the internal scheduler will run `func(i)` every 100ms:
+For `setInterval` the internal scheduler will run `func(i++)` every 100ms:
 
 ![](setinterval-interval.svg)
 


### PR DESCRIPTION
In **clarification drawing**(setinterval-interval.svg) `func `is calling with different argument values like `func(1)`, `func(2)` ...
But we can't see why variable `i` changing. Maybe we need `func(i++)` to explain this situation.