### PR TITLE
console.log() instead of alert()

### DIFF
--- a/1-js/03-code-quality/05-testing-mocha/article.md
+++ b/1-js/03-code-quality/05-testing-mocha/article.md
@@ -269,14 +269,14 @@ For instance:
 ```js no-beautify
 describe("test", function() {
 
-  before(() => alert("Testing started – before all tests"));
-  after(() => alert("Testing finished – after all tests"));
+  before(() => console.log("Testing started – before all tests"));
+  after(() => console.log("Testing finished – after all tests"));
 
-  beforeEach(() => alert("Before a test – enter a test"));
-  afterEach(() => alert("After a test – exit a test"));
+  beforeEach(() => console.log("Before a test – enter a test"));
+  afterEach(() => console.log("After a test – exit a test"));
 
-  it('test 1', () => alert(1));
-  it('test 2', () => alert(2));
+  it('test 1', () => console.log(1));
+  it('test 2', () => console.log(2));
 
 });
 ```


### PR DESCRIPTION
possible fix for issue #1523
alert() function exceeds **Mocha's time limit** for test run. So, mocha creates **timeout error** several times when we can't click "**ok**" button of alert() message immediately.

Also I think you worked with console.log() function when you were preparing for article but you converted it to alert(). Because you are talking about running sequence like console.log() outputs:

> Testing started – before all tests (before)
> Before a test – enter a test (beforeEach)
> 1
> After a test – exit a test   (afterEach)
> Before a test – enter a test (beforeEach)
> 2
> After a test – exit a test   (afterEach)
> Testing finished – after all tests (after)