### PR TITLE
wrapper instead of helper

### DIFF
--- a/1-js/06-advanced-functions/10-bind/article.md
+++ b/1-js/06-advanced-functions/10-bind/article.md
@@ -270,7 +270,7 @@ What if we'd like to fix some arguments, but not the context `this`? For example
 
 The native `bind` does not allow that. We can't just omit the context and jump to arguments.
 
-Fortunately, a helper function `partial` for binding only arguments can be easily implemented.
+Fortunately, a wrapper function `partial` for binding only arguments can be easily implemented.
 
 Like this:
 


### PR DESCRIPTION
"**helper function**" term reminds "**utility libraries**" but "**wrapper**" term refers "**function decorators**" and in this context, wrapper can be more self-descriptive and meaningful.