### PR TITLE
function instead of object

### DIFF
--- a/1-js/06-advanced-functions/10-bind/4-function-property-after-bind/solution.md
+++ b/1-js/06-advanced-functions/10-bind/4-function-property-after-bind/solution.md
@@ -1,4 +1,4 @@
 The answer: `undefined`.
 
-The result of `bind` is another object. It does not have the `test` property.
+The result of `bind` is another function. It does not have the `test` property.
 


### PR DESCRIPTION
 Functions are "**action objects**" but **object** term is insufficient in this context. So, **function** term can be more meaningful.