### PR TITLE
copy is not suit for this case

### DIFF
--- a/1-js/08-prototypes/03-native-prototypes/article.md
+++ b/1-js/08-prototypes/03-native-prototypes/article.md
@@ -157,7 +157,7 @@ alert( "La".repeat(3) ); // LaLaLa
 
 In the chapter <info:call-apply-decorators#method-borrowing> we talked about method borrowing.
 
-That's when we take a method from one object and copy it into another.
+That's when we take a method from one object and use it like another object's method.
 
 Some methods of native prototypes are often borrowed.
 


### PR DESCRIPTION
Copying method into another object differs from using call/apply, I think.
Functions are passed by reference and they are kind of special objects. So, copying of functions can make us recall wrong things like object copying or deep object copying etc.
If I copy a method into another object, I want to reach the method from the another object. But we can't do that by using call() or apply().