### PR TITLE
constructor function instead of constructor method

### DIFF
--- a/1-js/09-classes/01-class/article.md
+++ b/1-js/09-classes/01-class/article.md
@@ -106,7 +106,7 @@ class User {
 // class is a function
 alert(typeof User); // function
 
-// ...or, more precisely, the constructor method
+// ...or, more precisely, the constructor function 
 alert(User === User.prototype.constructor); // true
 
 // The methods are in User.prototype, e.g:


### PR DESCRIPTION
Constructor methods make us recall "**the constructor method in class declaration structure**". But in here, you show that the function has prototype object and this object has an attribute "constructor" which is a reference to the function itself. So we learn this pattern as a "constructor function" in this article:

https://javascript.info/function-prototype