### PR TITLE
"computed property name" instead of "computed property"

### DIFF
--- a/1-js/09-classes/01-class/article.md
+++ b/1-js/09-classes/01-class/article.md
@@ -282,7 +282,7 @@ Object.defineProperties(User.prototype, {
 });
 ```
 
-Here's an example with a computed property in brackets `[...]`:
+Here's an example with a computed property name in brackets `[...]`:
 
 ```js run
 class User {


### PR DESCRIPTION
"**computed property**" term can make us recall "**dynamically computed property**" like **fullname**. And it can create misunderstanding.

```
get fullname(){
    return this.name+ ' ' + this.surname;
}
```