### PR TITLE
example code must be unexecutable

### DIFF
--- a/1-js/09-classes/02-class-inheritance/article.md
+++ b/1-js/09-classes/02-class-inheritance/article.md
@@ -40,7 +40,7 @@ The syntax to extend another class is: `class Child extends Parent`.
 
 Let's create `class Rabbit` that inherits from `Animal`:
 
-```js run
+```js
 *!*
 class Rabbit extends Animal {
 */!*


### PR DESCRIPTION
Example code must be executable because, it is dependent on another example code above. So it can't work in plunker container.