### PR TITLE
non-executable code example doesn't need "run button".

### DIFF
--- a/1-js/09-classes/02-class-inheritance/article.md
+++ b/1-js/09-classes/02-class-inheritance/article.md
@@ -200,7 +200,7 @@ As we can see, it basically calls the parent `constructor` passing it all the ar
 
 Now let's add a custom constructor to `Rabbit`. It will specify the `earLength` in addition to `name`:
 
-```js run
+```js
 class Animal {
   constructor(name) {
     this.speed = 0;


### PR DESCRIPTION
Example code involves non-executable pseudo code. So the example code doesn't need **run button**.