### PR TITLE
Use `Number.isInteger()` to check integers

### DIFF
--- a/1-js/03-code-quality/05-testing-mocha/article.md
+++ b/1-js/03-code-quality/05-testing-mocha/article.md
@@ -354,7 +354,7 @@ So we should add a couple of lines to `pow`:
 function pow(x, n) {
 *!*
   if (n < 0) return NaN;
-  if (Math.round(n) != n) return NaN;
+  if (!Number.isInteger(n)) return NaN;
 */!*
 
   let result = 1;


### PR DESCRIPTION
Use `!Number.isInteger(n)` rather than `Math.round(n) != n`.