### PR TITLE
Update solution.md

### DIFF
--- a/1-js/05-data-types/07-map-set/02-filter-anagrams/solution.md
+++ b/1-js/05-data-types/07-map-set/02-filter-anagrams/solution.md
@@ -36,7 +36,7 @@ Letter-sorting is done by the chain of calls in the line `(*)`.
 For convenience let's split it into multiple lines:
 
 ```js
-let sorted = arr[i] // PAN
+let sorted = word // PAN
   .toLowerCase() // pan
   .split('') // ['p','a','n']
   .sort() // ['a','n','p']

--- a/1-js/09-classes/03-static-properties-methods/article.md
+++ b/1-js/09-classes/03-static-properties-methods/article.md
@@ -20,7 +20,7 @@ User.staticMethod(); // true
 That actually does the same as assigning it as a property directly:
 
 ```js run
-class User() { }
+class User { }
 
 User.staticMethod = function() {
   alert(this === User);

--- a/1-js/09-classes/03-static-properties-methods/article.md
+++ b/1-js/09-classes/03-static-properties-methods/article.md
@@ -20,7 +20,7 @@ User.staticMethod(); // true
 That actually does the same as assigning it as a property directly:
 
 ```js run
-class User { }
+class User() { }
 
 User.staticMethod = function() {
   alert(this === User);


### PR DESCRIPTION
Changed the reference to each item of `arr` since it was previously defined as the variable `word` (for...of loop) in the code block above. So, to be consistent, the same reference should be used when splitting the definition of `sorted` in multiple lines.