### PR TITLE
Fixing urls to start with 'https'

### DIFF
--- a/2-ui/2-events/04-default-browser-action/1-why-return-false-fails/solution.md
+++ b/2-ui/2-events/04-default-browser-action/1-why-return-false-fails/solution.md
@@ -20,7 +20,7 @@ The fix is simple:
   }
 </script>
 
-<a href="http://w3.org" onclick="*!*return handler()*/!*">w3.org</a>
+<a href="https://w3.org" onclick="*!*return handler()*/!*">w3.org</a>
 ```
 
 Also we can use `event.preventDefault()`, like this:
@@ -35,5 +35,5 @@ Also we can use `event.preventDefault()`, like this:
 */!*
 </script>
 
-<a href="http://w3.org" onclick="*!*handler(event)*/!*">w3.org</a>
+<a href="https://w3.org" onclick="*!*handler(event)*/!*">w3.org</a>
 ```

--- a/2-ui/2-events/04-default-browser-action/1-why-return-false-fails/task.md
+++ b/2-ui/2-events/04-default-browser-action/1-why-return-false-fails/task.md
@@ -14,7 +14,7 @@ Why in the code below `return false` doesn't work at all?
   }
 </script>
 
-<a href="http://w3.org" onclick="handler()">the browser will go to w3.org</a>
+<a href="https://w3.org" onclick="handler()">the browser will go to w3.org</a>
 ```
 
 The browser follows the URL on click, but we don't want it.

--- a/2-ui/2-events/04-default-browser-action/2-catch-link-navigation/solution.view/index.html
+++ b/2-ui/2-events/04-default-browser-action/2-catch-link-navigation/solution.view/index.html
@@ -16,7 +16,7 @@
   <fieldset id="contents">
     <legend>#contents</legend>
     <p>
-      How about to read <a href="http://wikipedia.org">Wikipedia</a> or visit <a href="http://w3.org"><i>W3.org</i></a> and learn about modern standards?
+      How about to read <a href="https://wikipedia.org">Wikipedia</a> or visit <a href="https://w3.org"><i>W3.org</i></a> and learn about modern standards?
     </p>
   </fieldset>
 

--- a/2-ui/2-events/04-default-browser-action/2-catch-link-navigation/source.view/index.html
+++ b/2-ui/2-events/04-default-browser-action/2-catch-link-navigation/source.view/index.html
@@ -16,7 +16,7 @@
   <fieldset id="contents">
     <legend>#contents</legend>
     <p>
-      How about to read <a href="http://wikipedia.org">Wikipedia</a> or visit <a href="http://w3.org"><i>W3.org</i></a> and learn about modern standards?
+      How about to read <a href="https://wikipedia.org">Wikipedia</a> or visit <a href="https://w3.org"><i>W3.org</i></a> and learn about modern standards?
     </p>
   </fieldset>
 


### PR DESCRIPTION
On the following page https://javascript.info/default-browser-action#catch-links-in-the-element 
the link will not redirect the page as expected. This happens because the links are http(not secure)
and most modern browsers block request redirecting to http links from https sites.
>Chrome Developer Console:
![image](https://user-images.githubusercontent.com/39612799/69640631-ac42ae00-1084-11ea-93be-73ae7890ef71.png)

closes #1622 