### PR TITLE
Update article.md

### DIFF
--- a/2-ui/2-events/05-dispatch-events/article.md
+++ b/2-ui/2-events/05-dispatch-events/article.md
@@ -211,7 +211,7 @@ Please note: the event must have the flag `cancelable: true`, otherwise the call
 
 ## Events-in-events are synchronous
 
-Usually events are processed asynchronously. That is: if the browser is processing `onclick` and in the process a new event occurs, then it awaits till `onclick` processing is finished.
+Usually events are processed asynchronously. That is: if the browser is processing `onclick` and in the process a new event occurs, then it waits until the `onclick` processing is finished.
 
 The exception is when one event is initiated from within another one.
 


### PR DESCRIPTION
'awaits till `onclick`' -> 'waits until the `onclick`'.

"awaits" doesn't usually go with "until" (or "till" or "'til"); I can await someone's arrival, or I can wait **until** they arrive. 

An alternate phrasing using "await" might be: "it awaits the completion of the `onclick` processing". But I wouldn't use it.