### PR TITLE
Update article.md

### DIFF
--- a/1-js/07-object-properties/01-property-descriptors/article.md
+++ b/1-js/07-object-properties/01-property-descriptors/article.md
@@ -66,7 +66,7 @@ Object.defineProperty(obj, propertyName, descriptor)
 : The object and its property to apply the descriptor.
 
 `descriptor`
-: Property descriptor to apply.
+: Property descriptor object to apply.
 
 If the property exists, `defineProperty` updates its flags. Otherwise, it creates the property with the given value and flags; in that case, if a flag is not supplied, it is assumed `false`.
 


### PR DESCRIPTION
Adding 'object' after 'Property descriptor' -- even though it is said not far above that the 'property descriptor' returned by `Object.getOwnPropertyDescriptor` is an object, I think it wouldn't hurt to discretely include that info here (though of course it's also implied by the usage in the examples). Especially if someone is quickly scanning the article looking for `Object.defineProperty` and didn't just read the part above.