### PR TITLE
Update article.md

### DIFF
--- a/1-js/06-advanced-functions/03-closure/article.md
+++ b/1-js/06-advanced-functions/03-closure/article.md
@@ -121,7 +121,7 @@ During the call, `say()` uses the outer variable `phrase`. Let's look at the det
 
 When a function runs, a new Lexical Environment is created automatically to store local variables and parameters of the call.
 
-For instance, for `say("John")`, it looks like this (the execution is at the line, labelled with an arrow):
+For instance, for `say("John")`, it looks like this (the execution is at the line labeled with an arrow):
 
 <!--
     ```js


### PR DESCRIPTION
Remove comma, change spelling of "labeled".

While both "labelled" and "labeled" are correct, "labeled" is the preferred American spelling (though the British spelling "labelled" is more logical, given the general rules of English spelling, such as they are, since the "e" sound before the "l" is short, not long). Still, probably better with American spelling.