### PR TITLE
Update 1-js/03-code-quality/05-testing-mocha/pow-2.view/test.js

### DIFF
--- a/1-js/03-code-quality/05-testing-mocha/pow-2.view/test.js
+++ b/1-js/03-code-quality/05-testing-mocha/pow-2.view/test.js
@@ -4,7 +4,7 @@ describe("pow", function() {
     assert.equal(pow(2, 3), 8);
   });
 
-  it("3 raised to power 3 is 27", function() {
+  it("3 raised to power 4 is 81", function() {
     assert.equal(pow(3, 4), 81);
   });
 

--- a/1-js/03-code-quality/05-testing-mocha/pow-2.view/test.js
+++ b/1-js/03-code-quality/05-testing-mocha/pow-2.view/test.js
@@ -5,7 +5,7 @@ describe("pow", function() {
   });
 
   it("3 raised to power 3 is 27", function() {
-    assert.equal(pow(3, 3), 27);
+    assert.equal(pow(3, 4), 81);
   });
 
 });


### PR DESCRIPTION
In the article, the test case is "3 raised to power 4 is 81", but in test.js, it is "3 raised to power 3 is 27".

Link: https://javascript.info/testing-mocha#improving-the-spec

I think it's a type error.


