### PR TITLE
remove incorrect info about synchronous postMessage

### DIFF
--- a/3-frames-and-windows/03-cross-window-communication/article.md
+++ b/3-frames-and-windows/03-cross-window-communication/article.md
@@ -335,10 +335,6 @@ The full example:
 
 [codetabs src="postmessage" height=120]
 
-```smart header="There's no delay"
-There's totally no delay between `postMessage` and the `message` event. The event triggers synchronously, faster than `setTimeout(...,0)`.
-```
-
 ## Summary
 
 To call methods and access the content of another window, we should first have a reference to it.


### PR DESCRIPTION
The text in the info-box is incorrect. `postMessage` is not synchronous, but indeed async.
It may have been synchronous in IE8 and lower as some resources claim, but it is not on current supported browsers.

An easy check to see that it is async, is to set a breakpoint, eg. via `debugger`, in the `onmessage` event handler and check the call stack.  here is a screenshot of the chrome debugger call stack:

![postMessage_async](https://user-images.githubusercontent.com/1710598/71246196-7fe22080-2316-11ea-95b8-28323e9ee892.png)

It also contradicts other documentation like [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#Notes).