### PR TITLE
change about how some code "waits" for something

### DIFF
--- a/1-js/11-async/02-promise-basics/article.md
+++ b/1-js/11-async/02-promise-basics/article.md
@@ -264,7 +264,7 @@ It's not exactly an alias of `then(f,f)` though. There are several important dif
 3. Last, but not least, `.finally(f)` is a more convenient syntax than `.then(f, f)`: no need to duplicate the function `f`.
 
 ````smart header="On settled promises handlers run immediately"
-If a promise is pending, `.then/catch/finally` handlers wait for it. Otherwise, if a promise has already settled, they execute immediately:
+If a promise is pending, `.then/catch/finally` handlers wait to be called. Otherwise, if a promise has already settled, they execute immediately:
 
 ```js run
 // the promise becomes resolved immediately upon creation


### PR DESCRIPTION
I can't think of a better way... somehow the idea of some code "waiting" for something is hard to think about. Is it by some kind of magical `.wait()` or by some kind of `sleep()` call?  I think the mechanism is: it just exists and waits to be called. I can't think of a better way to  put "wait for it" and "wait to be called" together.