### PR TITLE
Fixing a typo

### DIFF
--- a/9-regular-expressions/14-regexp-lookahead-lookbehind/article.md
+++ b/9-regular-expressions/14-regexp-lookahead-lookbehind/article.md
@@ -26,7 +26,7 @@ More complex tests are possible, e.g. `pattern:X(?=Y)(?=Z)` means:
 
 1. Find `pattern:X`.
 2. Check if `pattern:Y` is immediately after `pattern:X` (skip if isn't).
-3. Check if `pattern:Z` is immediately after `pattern:X` (skip if isn't).
+3. Check if `pattern:Z` is immediately after `pattern:Y` (skip if isn't).
 4. If both tests passed, then it's the match.
 
 In other words, such pattern means that we're looking for `pattern:X` followed by   `pattern:Y` and `pattern:Z` at the same time.


### PR DESCRIPTION
Check if `pattern:Y` is immediately after `pattern:X`  and then the regex will check if Z is immediately after Y,  Like this it's more understandable.