### PR TITLE
fix head variable redeclaration when pasting to browser dev tools

### DIFF
--- a/1-js/08-prototypes/01-prototype-inheritance/2-search-algorithm/solution.md
+++ b/1-js/08-prototypes/01-prototype-inheritance/2-search-algorithm/solution.md
@@ -2,13 +2,13 @@
 1. Let's add `__proto__`:
 
     ```js run
-    let head = {
+    let face = {
       glasses: 1
     };
 
     let table = {
       pen: 3,
-      __proto__: head
+      __proto__: face
     };
 
     let bed = {
@@ -29,4 +29,4 @@
 
 2. In modern engines, performance-wise, there's no difference whether we take a property from an object or its prototype. They remember where the property was found and reuse it in the next request.
 
-    For instance, for `pockets.glasses` they remember where they found `glasses` (in `head`), and next time will search right there. They are also smart enough to update internal caches if something changes, so that optimization is safe.
+    For instance, for `pockets.glasses` they remember where they found `glasses` (in `face`), and next time will search right there. They are also smart enough to update internal caches if something changes, so that optimization is safe.

--- a/1-js/08-prototypes/01-prototype-inheritance/2-search-algorithm/task.md
+++ b/1-js/08-prototypes/01-prototype-inheritance/2-search-algorithm/task.md
@@ -9,7 +9,7 @@ The task has two parts.
 Given the following objects:
 
 ```js
-let head = {
+let face = {
   glasses: 1
 };
 
@@ -27,5 +27,5 @@ let pockets = {
 };
 ```
 
-1. Use `__proto__` to assign prototypes in a way that any property lookup will follow the path: `pockets` -> `bed` -> `table` -> `head`. For instance, `pockets.pen` should be `3` (found in `table`), and `bed.glasses` should be `1` (found in `head`).
-2. Answer the question: is it faster to get `glasses` as `pockets.glasses` or `head.glasses`? Benchmark if needed.
+1. Use `__proto__` to assign prototypes in a way that any property lookup will follow the path: `pockets` -> `bed` -> `table` -> `face`. For instance, `pockets.pen` should be `3` (found in `table`), and `bed.glasses` should be `1` (found in `face`).
+2. Answer the question: is it faster to get `glasses` as `pockets.glasses` or `face.glasses`? Benchmark if needed.


### PR DESCRIPTION
When coping js from the task "Searching Algorythm" there is the error thrown
```js
SyntaxError: redeclaration of var head
```

Screenshots attached.
For Firefox:
![image](https://user-images.githubusercontent.com/30412774/74080396-b16f9200-4a11-11ea-9447-469213bc450e.png)

For latest Chrome:

![image](https://user-images.githubusercontent.com/30412774/74080448-483c4e80-4a12-11ea-85c5-31feeb7095f6.png)

