### PR TITLE
Incorrect precedence numbers (prob. "language-wide")

### DIFF
--- a/1-js/02-first-steps/07-operators/article.md
+++ b/1-js/02-first-steps/07-operators/article.md
@@ -138,10 +138,10 @@ Here's an extract from the [precedence table](https://developer.mozilla.org/en/J
 | Precedence | Name | Sign |
 |------------|------|------|
 | ... | ... | ... |
-| 16 | unary plus | `+` |
-| 16 | unary negation | `-` |
-| 14 | multiplication | `*` |
-| 14 | division | `/` |
+| 17 | unary plus | `+` |
+| 17 | unary negation | `-` |
+| 15 | multiplication | `*` |
+| 15 | division | `/` |
 | 13 | addition | `+` |
 | 13 | subtraction | `-` |
 | ... | ... | ... |


### PR DESCRIPTION
According to the MDN precedence-table you've linked some precedence numbers are incorrect. Having a quick look at different language versions (French and Russian) this error may has to be corrected at every version.