### PR TITLE
func.apply(context, args);   // is same as using apply => Is a type error?

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/article.md
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/article.md
@@ -300,7 +300,7 @@ So these two calls are almost equivalent:
 
 ```js
 func.call(context, ...args); // pass an array as list with spread syntax
-func.apply(context, args);   // is same as using apply
+func.apply(context, args);   // is same as using call
 ```
 
 There's only a minor difference:


### PR DESCRIPTION
Maybe `func.apply(context, args);   // is same as using apply` should be `func.apply(context, args);   // is same as using call`?

Change `is same as using apply` to `is same as using call`.


Thanks.