### PR TITLE
TypedArray only represents other classes.

### DIFF
--- a/4-binary/01-arraybuffer-binary-arrays/article.md
+++ b/4-binary/01-arraybuffer-binary-arrays/article.md
@@ -71,7 +71,7 @@ for(let num of view) {
 
 ## TypedArray
 
-The common term for all these views (`Uint8Array`, `Uint32Array`, etc) is [TypedArray](https://tc39.github.io/ecma262/#sec-typedarray-objects). They share the same set of methods and properities.
+The common term for all these views (`Uint8Array`, `Uint32Array`, etc) is [TypedArray](https://tc39.github.io/ecma262/#sec-typedarray-objects). They share the same set of methods and properities. (Note that there is no actual `TypedArray` global object; it is used here to represent one of `Int8Array()`, `Uint8Array()`, `Uint8ClampedArray()`, `Int16Array()`, `Uint16Array()`, `Int32Array()`, `Uint32Array()`, `Float32Array()`, `Float64Array()`, `BigInt64Array()`, of `BigUint64Array()`.)
 
 They are much more like regular arrays: have indexes and iterable.
 


### PR DESCRIPTION
This may not be the best way to explain it, but I was mislead by the way that TypedArray was included in code examples as if it were an actual class. The list is a little unwieldy, but I don’t see anywhere else in this article that lists them all.