### PR TITLE
fix: 2 stray lines of russian and a typo

### DIFF
--- a/9-regular-expressions/11-regexp-groups/article.md
+++ b/9-regular-expressions/11-regexp-groups/article.md
@@ -218,8 +218,8 @@ let results = '<h1> <h2>'.matchAll(/<(.*?)>/gi);
 
 for(let result of results) {
   alert(result);
-  // первый вывод: <h1>,h1
-  // второй: <h2>,h2
+  // first alert: <h1>,h1
+  // second: <h2>,h2
 }
 ```
 
@@ -249,7 +249,7 @@ The call to `matchAll` does not perform the search. Instead, it returns an itera
 
 So, there will be found as many results as needed, not more.
 
-E.g. there are potentially 100 matches in the text, but in a `for..of` loop we found 5 of them, then decided it's enough and make a `break`. Then the engine won't spend time finding other 95 mathces.
+E.g. there are potentially 100 matches in the text, but in a `for..of` loop we found 5 of them, then decided it's enough and make a `break`. Then the engine won't spend time finding other 95 matches.
 ```
 
 ## Named groups


### PR DESCRIPTION
**language fix:**

```
// первый вывод: <h1>,h1 -> // first alert: <h1>,h1
// второй: <h2>,h2 ->   // second: <h2>,h2
```


**typo fix:**
mathces -> matches