### PR TITLE
Change switch Grouping of "case" example

### DIFF
--- a/1-js/02-first-steps/13-switch/article.md
+++ b/1-js/02-first-steps/13-switch/article.md
@@ -117,7 +117,7 @@ Several variants of `case` which share the same code can be grouped.
 For example, if we want the same code to run for `case 3` and `case 5`:
 
 ```js run no-beautify
-let a = 2 + 2;
+let a = 3;
 
 switch (a) {
   case 4:


### PR DESCRIPTION
In 'Part1. The JavaScript language > Javascript Fundamentals > The "switch" statement > Grouping of case' example I think it is better to change `var a = 2+2(4)` to `3` because this example want to show grouping `case 3` and `case5`