### PR TITLE
fix typo

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/article.md
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/article.md
@@ -231,7 +231,7 @@ Previously, for a single argument `x` we could just `cache.set(x, result)` to sa
 There are many solutions possible:
 
 1. Implement a new (or use a third-party) map-like data structure that is more versatile and allows multi-keys.
-2. Use nested maps: `cache.set(min)` will be a `Map` that stores the pair `(max, result)`. So we can get `result` as `cache.get(min).get(max)`.
+2. Use nested maps: `cache.set(min)` will be a `Map` that stores the pair `(min, result)`. So we can get `result` as `cache.get(min).get(max)`.
 3. Join two values into one. In our particular case we can just use a string `"min,max"` as the `Map` key. For flexibility, we can allow to provide a *hashing function* for the decorator, that knows how to make one value from many.
 
 For many practical applications, the 3rd variant is good enough, so we'll stick to it.


### PR DESCRIPTION
I'm not sure if that is a normal or a typo
so, take a look please
you talk about "min" but you say the pair "max, result" instead , I think it should be "min, result"