### PR TITLE
Typo: Remove Duplicate Assignment

### DIFF
--- a/1-js/08-prototypes/02-function-prototype/article.md
+++ b/1-js/08-prototypes/02-function-prototype/article.md
@@ -27,7 +27,7 @@ function Rabbit(name) {
 Rabbit.prototype = animal;
 */!*
 
-let rabbit = new Rabbit("White Rabbit"); //  rabbit.__proto__ == animal
+let rabbit = new Rabbit("White Rabbit"); //  rabbit.__proto__ = animal
 
 alert( rabbit.eats ); // true
 ```


### PR DESCRIPTION
the first example, there is a duplicate assignment as a typo, so I fixed it.