### PR TITLE
docs: fix the typo in the dispatch events chapter

### DIFF
--- a/2-ui/2-events/05-dispatch-events/article.md
+++ b/2-ui/2-events/05-dispatch-events/article.md
@@ -211,7 +211,7 @@ Please note: the event must have the flag `cancelable: true`, otherwise the call
 
 ## Events-in-events are synchronous
 
-Usually events are processed asynchronously. That is: if the browser is processing `onclick` and in the process a new event occurs, then it waits until the `onclick` processing is finished.
+Usually events are processed synchronously. That is: if the browser is processing `onclick` and in the process a new event occurs, then it waits until the `onclick` processing is finished.
 
 The exception is when one event is initiated from within another one.
 


### PR DESCRIPTION
'Usually events are processed asynchronously.' should be 'Usually events are processed synchronously.'