### PR TITLE
add break to switch case example

### DIFF
--- a/1-js/02-first-steps/17-javascript-specials/article.md
+++ b/1-js/02-first-steps/17-javascript-specials/article.md
@@ -213,6 +213,7 @@ let age = prompt('Your age?', 18);
 switch (age) {
   case 18:
     alert("Won't work"); // the result of prompt is a string, not a number
+    break;
 
   case "18":
     alert("This works!");


### PR DESCRIPTION
Probably a good idea to include a break statement here so that the two cases are not grouped together.  If someone were to play around with this example in the sandbox, it could lead to unexpected results.