### PR TITLE
#1872 modify example

### DIFF
--- a/2-ui/5-loading/02-script-async-defer/article.md
+++ b/2-ui/5-loading/02-script-async-defer/article.md
@@ -146,8 +146,21 @@ That is:
 - They don't wait for anything, nothing waits for them.
 - The script that loads first -- runs first ("load-first" order).
 
-For example, here we add two scripts. Without `script.async=false` they would execute in load-first order (the `small.js` probably first). But with that flag the order is "as in the document":
+For example, here we add two scripts. They would execute in load-first order (the `small.js` probably first):
 
+```js run
+function loadScript(src) {
+  let script = document.createElement('script');
+  script.src = src;
+  document.body.append(script);
+}
+
+// small.js probably runs first
+loadScript("/article/script-async-defer/long.js");
+loadScript("/article/script-async-defer/small.js");
+```
+
+And if we explicitly set `script.async=false`, then scripts execute in the document order (the first appened always runs first, even if it's slow to load):
 
 ```js run
 function loadScript(src) {

--- a/2-ui/5-loading/02-script-async-defer/article.md
+++ b/2-ui/5-loading/02-script-async-defer/article.md
@@ -146,18 +146,6 @@ That is:
 - They don't wait for anything, nothing waits for them.
 - The script that loads first -- runs first ("load-first" order).
 
-
-```js run
-let script = document.createElement('script');
-script.src = "/article/script-async-defer/long.js";
-
-*!*
-script.async = false;
-*/!*
-
-document.body.append(script);
-```
-
 For example, here we add two scripts. Without `script.async=false` they would execute in load-first order (the `small.js` probably first). But with that flag the order is "as in the document":
 
 
@@ -165,7 +153,9 @@ For example, here we add two scripts. Without `script.async=false` they would ex
 function loadScript(src) {
   let script = document.createElement('script');
   script.src = src;
+*!*
   script.async = false;
+*/!*  
   document.body.append(script);
 }
 


### PR DESCRIPTION
https://github.com/javascript-tutorial/en.javascript.info/issues/1872

Why we need to assign the `false` on `async` to load the scripts in page order is already mentioned in the example below. So, I think it's better to remove the example above.