### PR TITLE
Fix Typo in logical operators

### DIFF
--- a/1-js/02-first-steps/11-logical-operators/article.md
+++ b/1-js/02-first-steps/11-logical-operators/article.md
@@ -128,8 +128,8 @@ This leads to some interesting usage compared to a "pure, classical, boolean-onl
     In the example below, the first message is printed, while the second is not:
 
     ```js run no-beautify
-    *!*true*/!* || alert("printed");
-    *!*false*/!* || alert("not printed");
+    *!*true*/!* || alert("not printed");
+    *!*false*/!* || alert("printed");
     ```
 
     In the first line, the OR `||` operator stops the evaluation immediately upon seeing `true`, so the `alert` isn't run.


### PR DESCRIPTION
```
true || alert("printed")
false || alert("not printed") 
```

This is confusing as the first won't be printed, but the second will print "not printed". I've reversed it so it makes more sense:

```
true || alert("not printed")
false || alert("printed")
```