### PR TITLE
Adding missing 'pattern:'

### DIFF
--- a/9-regular-expressions/05-regexp-multiline-mode/article.md
+++ b/9-regular-expressions/05-regexp-multiline-mode/article.md
@@ -54,7 +54,7 @@ Eeyore: 3`;
 alert( str.match(/\d$/gm) ); // 1,2,3
 ```
 
-Without the flag `m`, the dollar `pattern:$` would only match the end of the whole text, so only the very last digit would be found.
+Without the flag `pattern:m`, the dollar `pattern:$` would only match the end of the whole text, so only the very last digit would be found.
 
 ```smart
 "End of a line" formally means "immediately before a line break": the test  `pattern:$` in multiline mode matches at all positions succeeded by a newline character `\n`.


### PR DESCRIPTION
Adding missing 'pattern:' next to 'm' in the line "Without the flag `m`"