### PR TITLE
grammar fix: a plain object

### DIFF
--- a/1-js/05-data-types/07-map-set/article.md
+++ b/1-js/05-data-types/07-map-set/article.md
@@ -198,7 +198,7 @@ let prices = Object.fromEntries([
 alert(prices.orange); // 2
 ```
 
-We can use `Object.fromEntries` to get an plain object from `Map`.
+We can use `Object.fromEntries` to get a plain object from `Map`.
 
 E.g. we store the data in a `Map`, but we need to pass it to a 3rd-party code that expects a plain object.
 


### PR DESCRIPTION
"an plain object" -> "a plain object"