### PR TITLE
Fixed typos on last Array Methods task.

### DIFF
--- a/1-js/05-data-types/05-array-methods/12-reduce-object/_js.view/test.js
+++ b/1-js/05-data-types/05-array-methods/12-reduce-object/_js.view/test.js
@@ -8,13 +8,14 @@ describe("groupById", function() {
     ];
 
     assert.deepEqual(groupById(users), {
-      john: {id: 'john', name: "John Smith", age: 20}
+      john: {id: 'john', name: "John Smith", age: 20},
       ann: {id: 'ann', name: "Ann Smith", age: 24},
       pete: {id: 'pete', name: "Pete Peterson", age: 31},
     });
   });
 
   it("works with an empty array", function() {
+    users = [];
     assert.deepEqual(groupById(users), {});
   });
 });

--- a/1-js/05-data-types/05-array-methods/12-reduce-object/task.md
+++ b/1-js/05-data-types/05-array-methods/12-reduce-object/task.md
@@ -23,7 +23,7 @@ let usersById = groupById(users);
 // after the call we should have:
 
 usersById = {
-  john: {id: 'john', name: "John Smith", age: 20}
+  john: {id: 'john', name: "John Smith", age: 20},
   ann: {id: 'ann', name: "Ann Smith", age: 24},
   pete: {id: 'pete', name: "Pete Peterson", age: 31},
 }


### PR DESCRIPTION
The [last task](https://javascript.info/task/reduce-object) of the [Array Methods article](https://javascript.info/array-methods) has a test in the sandbox that had a couple typos.

- There was a missing comma in an object's list of keys.
- The second test used an undeclared variable.

I fixed both of those.