### PR TITLE
Details on cross-origin requests & credentials

### DIFF
--- a/5-network/05-fetch-crossorigin/article.md
+++ b/5-network/05-fetch-crossorigin/article.md
@@ -309,7 +309,7 @@ JavaScript only gets the response to the main request or an error if there's no 
 
 ## Credentials
 
-A cross-origin request by default does not bring any credentials (cookies or HTTP authentication).
+A cross-origin request initiated by JavaScript code by default does not bring any credentials (cookies or HTTP authentication).
 
 That's uncommon for HTTP-requests. Usually, a request to `http://site.com` is accompanied by all cookies from that domain. But cross-origin requests made by JavaScript methods are an exception.
 


### PR DESCRIPTION
Cross-origin requests initiated by embedded images and forms actually bring cookies by default (except for a SameSite = Lax or Strict cookie). Though it is incorrect to say that all cross-origin requests do not bring credentials by default.