### PR TITLE
Fix link rot in 1-js/06-advanced-functions/02-rest-parameters-spread

### DIFF
--- a/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
+++ b/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
@@ -227,7 +227,7 @@ So, for the task of turning something into an array, `Array.from` tends to be mo
 
 ## Get a new copy of an array/object
 
-Remember when we talked about `Object.assign()` [in the past](https://javascript.info/object#cloning-and-merging-object-assign)?
+Remember when we talked about `Object.assign()` [in the past](/object-copy#cloning-and-merging-object-assign)?
 
 It is possible to do the same thing with the spread syntax.
 


### PR DESCRIPTION
There's a link that references a section about Object.assign in 1-js/04-object-basics/01-object
but the actual section about Object.assign is in 1-js/04-object-basics/02-object-copy.

I followed the advice in AUTHORING.md and didn't include the domain.  However, I also
used the # character to reference the specific section.  I'm not sure if that will
work or not.