### PR TITLE
prototype-methods  shallow-clone remark

### DIFF
--- a/1-js/08-prototypes/04-prototype-methods/article.md
+++ b/1-js/08-prototypes/04-prototype-methods/article.md
@@ -57,11 +57,11 @@ The descriptors are in the same format as described in the chapter <info:propert
 We can use `Object.create` to perform an object cloning more powerful than copying properties in `for..in`:
 
 ```js
-// fully identical shallow clone of obj
+// fully identical 'shallow-clone' of obj
 let clone = Object.create(Object.getPrototypeOf(obj), Object.getOwnPropertyDescriptors(obj));
 ```
 
-This call makes a truly exact copy of `obj`, including all properties: enumerable and non-enumerable, data properties and setters/getters -- everything, and with the right `[[Prototype]]`.
+This call makes a truly exact ``shallow-copy`` of `obj`, including all properties: enumerable and non-enumerable, data properties and setters/getters -- everything, and with the right `[[Prototype]]`.
 
 ## Brief history
 


### PR DESCRIPTION
"fully identical shallow clone" seems contradictory in plain English.
It makes no much sense if you are learning, that's why I suggest to remark as a concept: 
identical 'shallow-clone' 
I wanted to put a reference to  <info:object-copy> 
but it's too weak there and I couldn't figure where to put it.
