### PR TITLE
Grammar fix: Missing "is" in websocket EN article

### DIFF
--- a/5-network/11-websocket/article.md
+++ b/5-network/11-websocket/article.md
@@ -15,7 +15,7 @@ let socket = new WebSocket("*!*ws*/!*://javascript.info");
 There's also encrypted `wss://` protocol. It's like HTTPS for websockets.
 
 ```smart header="Always prefer `wss://`"
-The `wss://` protocol not only encrypted, but also more reliable.
+The `wss://` protocol is not only encrypted, but also more reliable.
 
 That's because `ws://` data is not encrypted, visible for any intermediary. Old proxy servers do not know about WebSocket, they may see "strange" headers and abort the connection.
 


### PR DESCRIPTION
The english websocket article was missing an "in". I fixed it for you. :)