### PR TITLE
remove a stray 's' that caused an error in ball drag example

### DIFF
--- a/2-ui/3-event-details/4-mouse-drag-and-drop/ball2.view/index.html
+++ b/2-ui/3-event-details/4-mouse-drag-and-drop/ball2.view/index.html
@@ -13,7 +13,7 @@
 
 
   <script>
-    ball.onmousedown = function(event) {s
+    ball.onmousedown = function(event) {
       ball.style.position = 'absolute';
       ball.style.zIndex = 1000;
       document.body.appendChild(ball);


### PR DESCRIPTION
hello,

I found a stray 's' that caused one of the drag demos to be non-functional. 

also, thank you for creating such a wonderful javascript guide! :) I just discovered it today when I was looking around for some drag-and-drop examples using mousedown/up/move event listeners and the examples provided are a big help to me.