### PR TITLE
Update phrasing on "Comparison with ||"

### DIFF
--- a/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
+++ b/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
@@ -60,9 +60,9 @@ alert(height || 100); // 100
 alert(height ?? 100); // 0
 ```
 
-Here, `height || 100` treats zero height as unset, same as `null`, `undefined` or any other falsy value. So zero becames `100`.
+Here, `height || 100` treats zero height as unset, same as `null`, `undefined` or any other falsy value. So the alert shows `100`.
 
-The `height ?? 100` returns `100` only if `height` is exactly `null` or `undefined`. So zero remains "as is".
+The `height ?? 100` returns `100` only if `height` is exactly `null` or `undefined`. So the alert shows the height value `0` "as is".
 
 Which behavior is better depends on a particular use case. When zero height is a valid value, that we shouldn't touch, then `??` is preferrable.
 


### PR DESCRIPTION
The phrase `zero becames 100.` make me think that there is a variable `zero` defined when there is not.