### PR TITLE
Add bottom and right properties for getCoords()

### DIFF
--- a/2-ui/1-document/11-coordinates/article.md
+++ b/2-ui/1-document/11-coordinates/article.md
@@ -216,6 +216,8 @@ function getCoords(elem) {
 
   return {
     top: box.top + window.pageYOffset,
+    right: box.right + window.pageXOffset,
+    bottom: box.bottom + window.pageYOffset,
     left: box.left + window.pageXOffset
   };
 }


### PR DESCRIPTION
The `createMessageUnder()` function below needs the `bottom` coordinate, but it doesn't in the result of `getCoords()`.