### PR TITLE
Set fake timers before calling throttle

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/04-throttle/_js.view/test.js
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/04-throttle/_js.view/test.js
@@ -7,8 +7,8 @@ describe("throttle(f, 1000)", function() {
   }
 
   before(function() {
-    f1000 = throttle(f, 1000);
     this.clock = sinon.useFakeTimers();
+    f1000 = throttle(f, 1000);
   });
 
   it("the first call runs now", function() {


### PR DESCRIPTION
Calling throttle before setting the fake timers will break any implementations that save a timestamp outside the wrapper function. For example, the timeSinceLastUpdate in the first run will be negative in the following code:

```
 function throttle(func, ms){
	let lastUpdate = Date.now()-ms-1;
	let timerId;
	return function(...args){
		clearTimeout(timerId);
		let timeSinceLastUpdate = Date.now() - lastUpdate;
		let timeToNextUpdate = ms - timeSinceLastUpdate;

		if (timeSinceLastUpdate > ms){
			func.apply(this, args);
			lastUpdate = Date.now();
			return;
		}

		timerId = setTimeout( () => { 
			func.apply(this, args);
			lastUpdate = Date.now();
		}, timeToNextUpdate);
			
	}
}
```