### PR TITLE
x is an operand at ( typeof x )

### DIFF
--- a/1-js/02-first-steps/05-types/article.md
+++ b/1-js/02-first-steps/05-types/article.md
@@ -208,7 +208,7 @@ The `symbol` type is used to create unique identifiers for objects. We have to m
 
 ## The typeof operator [#type-typeof]
 
-The `typeof` operator returns the type of the argument. It's useful when we want to process values of different types differently or just want to do a quick check.
+The `typeof` operator returns the type of the operand/argument. It's useful when we want to process values of different types differently or just want to do a quick check.
 
 It supports two forms of syntax:
 


### PR DESCRIPTION
naming of `x` changes depends on usage of `typeof`(as a function or operator)
1. As an operator: `typeof x`.  --> `x `is an **operand**
2. As a function: `typeof(x)`.   --> `x `is an **argument**