### PR TITLE
clarifying the example

### DIFF
--- a/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
+++ b/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
@@ -90,7 +90,9 @@ That would work be the same as:
 
 ```js
 // probably not correct
-let area = height ?? (100 * width) ?? 50;
+let area = height ?? 100 * width ?? 50; // multiplication operation be performed first
+
+alert(area); // 0
 ```
 
 There's also a related language-level limitation.


### PR DESCRIPTION
There is a conflict between explanation and example. 
_"Otherwise, if we omit parentheses, ... "_
But in the example of this words, there are some extra parentheses. these parentheses make the article difficult to understand.
Also I added result of example which is  without parentheses to see difference clearly.