### PR TITLE
Update article.md

### DIFF
--- a/1-js/99-js-misc/05-bigint/article.md
+++ b/1-js/99-js-misc/05-bigint/article.md
@@ -50,7 +50,7 @@ The conversion operations are always silent, never give errors, but if the bigin
 ````smart header="The unary plus is not supported on bigints"
 The unary plus operator `+value` is a well-known way to convert `value` to a number.
 
-On bigints it's not supported, to avoid confusion:
+On bigints it's not supported to avoid confusion:
 ```js run
 let bigint = 1n;
 


### PR DESCRIPTION
No changes intended by my own
line 53
Dont know English.  I should avoid the coma in Spanish. 
You mean: 
To avoid confusion: (example)
or 
To avoid (ambiguity? should truncate? should leave bigint?) confusion,  it's not supported on bigints: