### PR TITLE
minor fixes: There is no character type.

### DIFF
--- a/1-js/02-first-steps/05-types/article.md
+++ b/1-js/02-first-steps/05-types/article.md
@@ -127,7 +127,7 @@ We'll cover strings more thoroughly in the chapter <info:string>.
 ```smart header="There is no *character* type."
 In some languages, there is a special "character" type for a single character. For example, in the C language and in Java it is called "char".
 
-In JavaScript, there is no such type. There's only one type: `string`. A string may consist of only one character or many of them.
+In JavaScript, there is no such type. There's only one type: `string`. A string may consist of zero character or many of them.
 ```
 
 ## Boolean (logical type)


### PR DESCRIPTION
minor fixes
[String](https://javascript.info/types#string) in **There is no character type.** 
> In JavaScript, there is no such type. There's only one type: `string`. A string may consist of only one character or many of them.

A string may consist of ~~only one~~ character or many of them.
->
A string may consist of **zero** character or many of them.