### PR TITLE
One line of code creates a lot of confusing

### DIFF
--- a/1-js/08-prototypes/03-native-prototypes/article.md
+++ b/1-js/08-prototypes/03-native-prototypes/article.md
@@ -33,7 +33,9 @@ We can check it like this:
 let obj = {};
 
 alert(obj.__proto__ === Object.prototype); // true
-// obj.toString === obj.__proto__.toString == Object.prototype.toString
+
+alert(obj.toString === obj.__proto__.toString); //true
+alert(obj.toString === Object.prototype.toString); //true
 ```
 
 Please note that there is no more `[[Prototype]]` in the chain above `Object.prototype`:


### PR DESCRIPTION
`// obj.toString === obj.__proto__.toString == Object.prototype.toString`

It is look like JS code but it gives different result from what we want to get.
There is different kind of equality operator and these give more confusing about what is the purpose of these?

Purpose of the line of code is showing correctness of these words.
> So then when obj.toString() is called the method is taken from Object.prototype.

So, it can be better to separate this line into 2 line of code to make it sensible and readable.
Subject and code is already hard but there is no need to make readers ask unnecessary questions.

