### PR TITLE
clarifying example code

### DIFF
--- a/1-js/08-prototypes/01-prototype-inheritance/article.md
+++ b/1-js/08-prototypes/01-prototype-inheritance/article.md
@@ -197,6 +197,9 @@ alert(admin.fullName); // John Smith (*)
 
 // setter triggers!
 admin.fullName = "Alice Cooper"; // (**)
+
+alert(admin.fullName); // Alice Cooper , state of admin modified
+alert(user.fullName); // John Smith , state of user protected
 ```
 
 Here in the line `(*)` the property `admin.fullName` has a getter in the prototype `user`, so it is called. And in the line `(**)` the property has a setter in the prototype, so it is called.


### PR DESCRIPTION
> An interesting question may arise in the example above: what’s the value of this inside set fullName(value)? Where are the properties this.name and this.surname written: into user or admin?
> 
> The answer is simple: this is not affected by prototypes at all.
> 
> No matter where the method is found: in an object or its prototype. In a method call, this is always the object before the dot.
> 
> So, the setter call admin.fullName= uses admin as this, not user.
> 
> That is actually a super-important thing, because we may have a big object with many methods, and have objects that inherit from it. And when the inheriting objects run the inherited methods, they will modify only their own states, not the state of the big object.

The example code doesn't show these concepts. Also, these additions can make readers ask questions before the explanation of the example code.