### PR TITLE
suggestion to use alert method not console.log

### DIFF
--- a/1-js/09-classes/02-class-inheritance/article.md
+++ b/1-js/09-classes/02-class-inheritance/article.md
@@ -545,7 +545,7 @@ Here's the demo of a wrong `super` result after copying:
 ```js run
 let animal = {
   sayHi() {
-    console.log(`I'm an animal`);
+    alert(`I'm an animal`);
   }
 };
 
@@ -559,7 +559,7 @@ let rabbit = {
 
 let plant = {
   sayHi() {
-    console.log("I'm a plant");
+    alert("I'm a plant");
   }
 };
 


### PR DESCRIPTION
I think it'd be better to use `alert` not `console.log` as opening the developer console is inconvenient from the user's perspective.