### PR TITLE
Change "settles" to "fulfils"

### DIFF
--- a/1-js/11-async/08-async-await/article.md
+++ b/1-js/11-async/08-async-await/article.md
@@ -65,7 +65,7 @@ async function f() {
 f();
 ```
 
-The function execution "pauses" at the line `(*)` and resumes when the promise settles, with `result` becoming its result. So the code above shows "done!" in one second.
+The function execution "pauses" at the line `(*)` and resumes when the promise fulfils, with `result` becoming its result. So the code above shows "done!" in one second.
 
 Let's emphasize: `await` literally suspends the function execution until the promise settles, and then resumes it with the promise result. That doesn't cost any CPU resources, because the JavaScript engine can do other jobs in the meantime: execute other scripts, handle events, etc.
 


### PR DESCRIPTION
I suggest using the word "fulfils" instead of "settles" to be consistent with the States and Fates document: https://github.com/domenic/promises-unwrapping/blob/master/docs/states-and-fates.md.