### PR TITLE
Typo Fixed

### DIFF
--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -179,7 +179,7 @@ alert( from ); // Ann
 
 If a parameter is not provided, then its value becomes `undefined`.
 
-For instance, the aforementioned function `showMessage(from, text)` can be called with a single argument:
+For instance, the above mentioned function `showMessage(from, text)` can be called with a single argument:
 
 ```js
 showMessage("Ann");


### PR DESCRIPTION
Fixed the typo of the Chapter JavaScript Fundamentals
Topic: Functions
Lesson Navigation: Default Values.
The second paragraph of the topic contained a sentence containing typo:
For instance, the aforementioned function showMessage(from, text) can be called with a single argument:
the typo is afroementioned which should have been as: above mentioned functions which is trying to point a function
defined above showMessage(from,text) function in the chapter function.