### PR TITLE
1.4.1.8_multiply numeric - Update 'properties' to 'property values'

### DIFF
--- a/1-js/04-object-basics/01-object/8-multiply-numeric/task.md
+++ b/1-js/04-object-basics/01-object/8-multiply-numeric/task.md
@@ -2,9 +2,9 @@ importance: 3
 
 ---
 
-# Multiply numeric properties by 2
+# Multiply numeric property values by 2
 
-Create a function `multiplyNumeric(obj)` that multiplies all numeric properties of `obj` by `2`.
+Create a function `multiplyNumeric(obj)` that multiplies all numeric property values of `obj` by `2`.
 
 For instance:
 


### PR DESCRIPTION
The task asks to multiply numeric object 'properties', 
however the term 'object properties' include both the 'property keys' of the object as well as the 'property values' of the object. 
It is clear the intention of the task is to change only property values.
This minor change improves clarity of the task description.