### PR TITLE
OPT: change "false" to "falsy"

### DIFF
--- a/1-js/06-advanced-functions/01-recursion/article.md
+++ b/1-js/06-advanced-functions/01-recursion/article.md
@@ -132,7 +132,7 @@ We can sketch it as:
   </li>
 </ul>
 
-That's when the function starts to execute. The condition `n == 1` is false, so the flow continues into the second branch of `if`:
+That's when the function starts to execute. The condition `n == 1` is falsy, so the flow continues into the second branch of `if`:
 
 ```js run
 function pow(x, n) {


### PR DESCRIPTION
`falsy` if better? Because in line 230:

```
the condition `n == 1` is truthy
```

`truthy` is used in line 230, so maybe there `falsy` is better?