### PR TITLE
Replace rules.indent array with number

### DIFF
--- a/1-js/03-code-quality/02-coding-style/article.md
+++ b/1-js/03-code-quality/02-coding-style/article.md
@@ -328,7 +328,7 @@ Here's an example of an `.eslintrc` file:
   },
   "rules": {
     "no-console": 0,
-    "indent": ["warning", 2]
+    "indent": 2
   }
 }
 ```


### PR DESCRIPTION
ESLint 7.12.0 indent rule configuration now only accepts a number value. The array provided returns a runtime error.