### PR TITLE
Change `var` to `let` in 7.16 regexp-sticky

### DIFF
--- a/9-regular-expressions/16-regexp-sticky/article.md
+++ b/9-regular-expressions/16-regexp-sticky/article.md
@@ -13,7 +13,7 @@ E.g. we have a code string `subject:let varName = "value"`, and we need to read 
 
 We'll look for variable name using regexp `pattern:\w+`. Actually, JavaScript variable names need a bit more complex regexp for accurate matching, but here it doesn't matter.
 
-- A call to `str.match(/\w+/)` will find only the first word in the line (`var`). That's not it.
+- A call to `str.match(/\w+/)` will find only the first word in the line (`let`). That's not it.
 - We can add the flag `pattern:g`. But then the call `str.match(/\w+/g)` will look for all words in the text, while we need one word at position `4`. Again, not what we need.
 
 **So, how to search for a regexp exactly at the given position?**


### PR DESCRIPTION
This should resolve #2247.

Commit 10d1b1f25 added a hint about which word would be found by a certain regexp:

> A call to `str.match(/\w+/)` will find only the first word in the line (`var`). That’s not it.

Unfortunately the result is incorrect: the regexp would find `let`, not `var`.

Updating the hint should resolve any confusion. I've double-checked the example, in the console, to ensure that the regexp does indeed find `let`.