### PR TITLE
Correct comment in 1.13.1

### DIFF
--- a/1-js/13-modules/01-modules-intro/article.md
+++ b/1-js/13-modules/01-modules-intro/article.md
@@ -260,7 +260,7 @@ Compare to regular script below:
 
 <script>
 *!*
-  alert(typeof button); // Error: button is undefined, the script can't see elements below
+  alert(typeof button); // button is undefined, the script can't see elements below
 */!*
   // regular scripts run immediately, before the rest of the page is processed
 </script>


### PR DESCRIPTION
Strictly speaking, there is no error here, as `typeof` does not produce errors with undefined variables.