### PR TITLE
Added comment for better understanding

### DIFF
--- a/1-js/11-async/01-callbacks/article.md
+++ b/1-js/11-async/01-callbacks/article.md
@@ -70,6 +70,7 @@ function loadScript(src, *!*callback*/!*) {
   script.src = src;
 
 *!*
+  // Local variables passed in as arguments will be available for use later in the callback scope
   script.onload = () => callback(script);
 */!*
 


### PR DESCRIPTION
For a newbie, it's not clear enough at this point that local variables passed in as arguments to the callback are somehow "transferred" and that they are available to use later on the callback we add as a second parameter on the main function. So, the argument we add to the callback will be the one we've passed in internally on the function that called the callback function.