### PR TITLE
undefined instead of null for empty argument

### DIFF
--- a/1-js/11-async/02-promise-basics/article.md
+++ b/1-js/11-async/02-promise-basics/article.md
@@ -291,7 +291,7 @@ function loadScript(src, callback) {
   let script = document.createElement('script');
   script.src = src;
 
-  script.onload = () => callback(null, script);
+  script.onload = () => callback(undefined, script);
   script.onerror = () => callback(new Error(`Script load error for ${src}`));
 
   document.head.append(script);


### PR DESCRIPTION
Using `undefined` instead of `null` is more convenient for pass empty argument to a function. For the  example snippet, every thing is okay. it works but in general we must send `undefined` valued argument to trigger **default parameter value** mechanism of JavaScript functions. For the example code we can pass any uncallable value instead of `null`, but `undefined` is more convenient for the purpose.

