### PR TITLE
Include missing fileServer

### DIFF
--- a/5-network/12-server-sent-events/eventsource.view/server.js
+++ b/5-network/12-server-sent-events/eventsource.view/server.js
@@ -1,6 +1,8 @@
 let http = require('http');
 let url = require('url');
 let querystring = require('querystring');
+let static = require('node-static');
+let fileServer = new static.Server('.');
 
 function onDigits(req, res) {
   res.writeHead(200, {
@@ -36,7 +38,6 @@ function accept(req, res) {
   }
 
   fileServer.serve(req, res);
-
 }
 
 


### PR DESCRIPTION
In the `accept` method, 
`fileServer.serve(req, res)` was called however, noticed that it has not been initialized hence the change