### PR TITLE
Fix solution in data types - string - truncate

### DIFF
--- a/1-js/05-data-types/03-string/3-truncate/solution.md
+++ b/1-js/05-data-types/03-string/3-truncate/solution.md
@@ -5,6 +5,6 @@ Note that there is actually a single unicode character for an ellipsis. That's n
 ```js run demo
 function truncate(str, maxlength) {
   return (str.length > maxlength) ?
-    str.slice(0, maxlength - 1) + '…' : str;
+    str.slice(0, maxlength) + '…' : str;
 }
 ```


### PR DESCRIPTION
`truncate('Hello',2) // 'He…'` because slice takes substring from the first param to (but not including) second param.