### PR TITLE
revoked proxies purpose

### DIFF
--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -963,7 +963,7 @@ revoke();
 alert(proxy.data); // Error
 ```
 
-A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object can be garbage-collected after that.
+A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. Any further attempt to access it will throw a distinctive error you can catch.
 
 We can also store `revoke` in a `WeakMap`, to be able to easily find it by a proxy object:
 

--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -963,7 +963,7 @@ revoke();
 alert(proxy.data); // Error
 ```
 
-A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. Any further attempt to access it will throw a distinctive error you can catch.
+A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object can be garbage-collected after that. But unlike regular proxies, Proxy.revocable() creates a clon of the original object as a target, so you can still access to object.data.   
 
 We can also store `revoke` in a `WeakMap`, to be able to easily find it by a proxy object:
 

--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -964,7 +964,7 @@ revoke();
 alert(proxy.data); // Error
 ```
 
-A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object can be garbage-collected after that.   
+A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object could be garbage-collected after that.
 
 We can also store `revoke` in a `WeakMap`, to be able to easily find it by a proxy object:
 

--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -964,7 +964,7 @@ revoke();
 alert(proxy.data); // Error
 ```
 
-A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object could be garbage-collected after that.
+A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object can be garbage-collected after that.
 
 We can also store `revoke` in a `WeakMap`, to be able to easily find it by a proxy object:
 

--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -952,6 +952,7 @@ let object = {
 };
 
 let {proxy, revoke} = Proxy.revocable(object, {});
+object = null; // use proxy from now on
 
 // pass the proxy somewhere instead of object...
 alert(proxy.data); // Valuable data
@@ -963,7 +964,7 @@ revoke();
 alert(proxy.data); // Error
 ```
 
-A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object can be garbage-collected after that. But unlike regular proxies, Proxy.revocable() creates a clon of the original object as a target, so you can still access to object.data.   
+A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object can be garbage-collected after that.   
 
 We can also store `revoke` in a `WeakMap`, to be able to easily find it by a proxy object:
 

--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -952,7 +952,6 @@ let object = {
 };
 
 let {proxy, revoke} = Proxy.revocable(object, {});
-object = null; // use proxy from now on
 
 // pass the proxy somewhere instead of object...
 alert(proxy.data); // Valuable data
@@ -964,7 +963,7 @@ revoke();
 alert(proxy.data); // Error
 ```
 
-A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object can be garbage-collected after that.
+A call to `revoke()` removes all internal references to the target object from the proxy, so they are no longer connected. The target object could be garbage-collected after that, but in our example `object` variable is still referencing it.
 
 We can also store `revoke` in a `WeakMap`, to be able to easily find it by a proxy object:
 


### PR DESCRIPTION
"The target object can be garbage-collected after that."  
  yes... but no   : )  @iliakan  
"object" in this code is still alive, "proxy" disables itself and kills just a target clone inside it.
 
```
...
// the proxy isn't working any more (revoked)
alert(proxy.data); // Error
alert(object.data); //  still working
```
..unless I add right after proxy creation: 
`object = proxy;  //   transparency 
`
so it performs like the rest of the examples, a replacement.   (let {object, revoke} = .... object didnt work)
I would add it to the PR, but I can't see the point of revocable so I don't know what's useful for.

The "distictive error" is the only thing I see different from a plain delete, so I suggested it. 
