### PR TITLE
Fixed small typo

### DIFF
--- a/2-ui/2-events/05-dispatch-events/article.md
+++ b/2-ui/2-events/05-dispatch-events/article.md
@@ -8,7 +8,7 @@ We can generate not only completely new events, that we invent for our own purpo
 
 ## Event constructor
 
-Build-in event classes form a hierarchy, similar to DOM element classes. The root is the built-in [Event](http://www.w3.org/TR/dom/#event) class.
+Built-in event classes form a hierarchy, similar to DOM element classes. The root is the built-in [Event](http://www.w3.org/TR/dom/#event) class.
 
 We can create `Event` objects like this:
 

--- a/5-network/02-formdata/article.md
+++ b/5-network/02-formdata/article.md
@@ -47,7 +47,7 @@ As you can see, that's almost one-liner:
 </script>
 ```
 
-In this example, the server code is not presented, as it's beyound our scope. The server accepts the POST request and replies "User saved".
+In this example, the server code is not presented, as it's beyond our scope. The server accepts the POST request and replies "User saved".
 
 ## FormData Methods
 


### PR DESCRIPTION
2-ui / 2-events / 5-dispatch-events

In subchapter "Event constructor": first word use "Built-in" instead of "Build-in"