### PR TITLE
Fix confusing wording in 9.6 (Word boundary: \b)

### DIFF
--- a/9-regular-expressions/06-regexp-boundary/article.md
+++ b/9-regular-expressions/06-regexp-boundary/article.md
@@ -27,7 +27,7 @@ So, it matches the pattern `pattern:\bHello\b`, because:
 2. Then matches the word `pattern:Hello`.
 3. Then the test `pattern:\b` matches again, as we're between `subject:o` and a comma.
 
-The pattern `pattern:\bHello\b` would also match. But not `pattern:\bHell\b` (because there's no word boundary after `l`) and not `Java!\b` (because the exclamation sign is not a wordly character `pattern:\w`, so there's no word boundary after it).
+So the pattern `pattern:\bHello\b` would match, but not `pattern:\bHell\b` (because there's no word boundary after `l`) and not `Java!\b` (because the exclamation sign is not a wordly character `pattern:\w`, so there's no word boundary after it).
 
 ```js run
 alert( "Hello, Java!".match(/\bHello\b/) ); // Hello


### PR DESCRIPTION
`\bHello\b` pattern was just analyzed in the previous paragraph, so the current wording is a bit confusing.