### PR TITLE
Add information about virtual/mobile keyboards and an additional keyboard event inspection tool.

### DIFF
--- a/2-ui/3-event-details/7-keyboard-events/article.md
+++ b/2-ui/3-event-details/7-keyboard-events/article.md
@@ -174,7 +174,7 @@ There were so many browser incompatibilities while working with them, that devel
 
 ## Mobile Keyboards
 
-When using virtual/mobile keyboards, formally know as IME (Input-Method Editor), the W3C standard states that a KeyboardEvent's [`e.keyCode` should be `229`](https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode) and [`e.key` should be `"Unidentified"`](https://www.w3.org/TR/uievents-key/#key-attr-values).
+When using virtual/mobile keyboards, formally known as IME (Input-Method Editor), the W3C standard states that a KeyboardEvent's [`e.keyCode` should be `229`](https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode) and [`e.key` should be `"Unidentified"`](https://www.w3.org/TR/uievents-key/#key-attr-values).
 
 While some of these keyboards might still use the right values for `e.key`, `e.code`, `e.keyCode`... when pressing certain keys such as arrows or backspace, there's no guarantee, so your keyboard logic might not always work on mobile devices.
 

--- a/2-ui/3-event-details/7-keyboard-events/article.md
+++ b/2-ui/3-event-details/7-keyboard-events/article.md
@@ -21,6 +21,8 @@ Try different key combinations in the text field.
 [codetabs src="keyboard-dump" height=480]
 ```
 
+If you'd like to see some of the many other properties inside a `KeyboardEvent`, you can use [Key.js](https://keyjs.dev), a similar keyboard event inspection tool.
+
 
 ## Keydown and keyup
 
@@ -169,6 +171,12 @@ Now arrows and deletion works well.
 In the past, there was a `keypress` event, and also `keyCode`, `charCode`, `which` properties of the event object.
 
 There were so many browser incompatibilities while working with them, that developers of the specification had no way, other than deprecating all of them and creating new, modern events (described above in this chapter). The old code still works, as browsers keep supporting them, but there's totally no need to use those any more.
+
+## Mobile Keyboards
+
+When using virtual/mobile keyboards, formally know as IME (Input-Method Editor), the W3C standard states that a KeyboardEvent's [`e.keyCode` should be `229`](https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode) and [`e.key` should be `"Unidentified"`](https://www.w3.org/TR/uievents-key/#key-attr-values).
+
+While some of these keyboards might still use the right values for `e.key`, `e.code`, `e.keyCode`... when pressing certain keys such as arrows or backspace, there's no guarantee, so your keyboard logic might not always work on mobile devices.
 
 ## Summary
 

--- a/2-ui/3-event-details/7-keyboard-events/article.md
+++ b/2-ui/3-event-details/7-keyboard-events/article.md
@@ -21,8 +21,6 @@ Try different key combinations in the text field.
 [codetabs src="keyboard-dump" height=480]
 ```
 
-If you'd like to see some of the many other properties inside a `KeyboardEvent`, you can use [Key.js](https://keyjs.dev), a similar keyboard event inspection tool.
-
 
 ## Keydown and keyup
 


### PR DESCRIPTION
There's a comment from a user on this page that says "This works well on desktop but fails on Android".

I replied with what might be the issue (it's usually not possible to identify most pressed keys on mobile keyboards), but it looks like that message needs to be approved first and might be easy to miss, so I added an additional section on this page to explain this fairly common issue.