### PR TITLE
removed async keyword

### DIFF
--- a/1-js/11-async/08-async-await/article.md
+++ b/1-js/11-async/08-async-await/article.md
@@ -27,7 +27,7 @@ f().then(alert); // 1
 ...We could explicitly return a promise, which would be the same:
 
 ```js run
-async function f() {
+function f() {
   return Promise.resolve(1);
 }
 


### PR DESCRIPTION
In fourth example we had async keyword in front of the function declaration, which was unnecessary since author is showing how we can explicitly return a promise without async keyword.