### PR TITLE
Minor output typo

### DIFF
--- a/1-js/09-classes/02-class-inheritance/article.md
+++ b/1-js/09-classes/02-class-inheritance/article.md
@@ -151,7 +151,7 @@ class Rabbit extends Animal {
 let rabbit = new Rabbit("White Rabbit");
 
 rabbit.run(5); // White Rabbit runs with speed 5.
-rabbit.stop(); // White Rabbit stands still. White rabbit hides!
+rabbit.stop(); // White Rabbit stands still. White Rabbit hides!
 ```
 
 Now `Rabbit` has the `stop` method that calls the parent `super.stop()` in the process.


### PR DESCRIPTION
In the section describing the usage of `"super"`, example output says `// White Rabbit stands still. White rabbit hides!`

The `name` member in this example is set to `White Rabbit`, so the second sentence above should say `White Rabbit hides!` (capital R)