### PR TITLE
new.target is undefined not empty

### DIFF
--- a/1-js/04-object-basics/06-constructor-new/article.md
+++ b/1-js/04-object-basics/06-constructor-new/article.md
@@ -91,7 +91,7 @@ The syntax from this section is rarely used, skip it unless you want to know eve
 
 Inside a function, we can check whether it was called with `new` or without it, using a special `new.target` property.
 
-It is empty for regular calls and equals the function if called with `new`:
+It is undefined for regular calls and equals the function if called with `new`:
 
 ```js run
 function User() {


### PR DESCRIPTION
It is should be made know that `new.target` is `undefined` for regular function calls than say it is empty.