### PR TITLE
"bigint" is also numeric type

### DIFF
--- a/1-js/04-object-basics/01-object/8-multiply-numeric/task.md
+++ b/1-js/04-object-basics/01-object/8-multiply-numeric/task.md
@@ -2,9 +2,9 @@ importance: 3
 
 ---
 
-# Multiply numeric property values by 2
+# Multiply number typed property values by 2
 
-Create a function `multiplyNumeric(obj)` that multiplies all numeric property values of `obj` by `2`.
+Create a function `multiplyNumeric(obj)` that multiplies all number typed property values of `obj` by `2`.
 
 For instance:
 


### PR DESCRIPTION
To keep question simple and precise we could change "numeric" with "number typed". Because term numeric involves both "number" type and "bigint" type. But the solution and test cases want us to solve this question for "number" type.