### PR TITLE
declarations vs calls

### DIFF
--- a/1-js/04-object-basics/03-garbage-collection/article.md
+++ b/1-js/04-object-basics/03-garbage-collection/article.md
@@ -15,7 +15,7 @@ Simply put, "reachable" values are those that are accessible or usable somehow. 
     For instance:
 
     - Local variables and parameters of the current function.
-    - Variables and parameters for other functions on the current chain of nested calls.
+    - Variables and parameters for other functions on the current chain of nested declarations.
     - Global variables.
     - (there are some other, internal ones as well)
 


### PR DESCRIPTION
I think article talks about "closures". If we talk about closures, calling a function in another function does not create links if arguments are not objects.
So if the subject is "closures", it should be "declarations" instead of "calls".