### PR TITLE
optional chaining always returns undefined

### DIFF
--- a/1-js/04-object-basics/07-optional-chaining/article.md
+++ b/1-js/04-object-basics/07-optional-chaining/article.md
@@ -74,7 +74,7 @@ That's why the optional chaining `?.` was added to the language. To solve this p
 
 ## Optional chaining
 
-The optional chaining `?.` stops the evaluation if the part before `?.` is `undefined` or `null` and returns that part.
+The optional chaining `?.` stops the evaluation if the part before `?.` is `undefined` or `null` and returns that part as `undefined`.
 
 **Further in this article, for brevity, we'll be saying that something "exists" if it's not `null` and not `undefined`.**
 


### PR DESCRIPTION
optional chaining returns undefined for null and undefined

```
let user1 = {name:undefined};
let user2 = {name:null};
```

```
user1.name?.toUpperCase(); //undefined
user2.name?.toUpperCase(); //undefined
```

but article says that it can return null for some cases like this
`user2.name?.toUpperCase(); //null   --> this is not possible`