### PR TITLE
Fix mismatched alert text

### DIFF
--- a/1-js/02-first-steps/14-switch/article.md
+++ b/1-js/02-first-steps/14-switch/article.md
@@ -47,7 +47,7 @@ switch (a) {
     break;
 */!*
   case 5:
-    alert( 'Too large' );
+    alert( 'Too big' );
     break;
   default:
     alert( "I don't know such values" );


### PR DESCRIPTION
Fixed mismatched alert text on "The 'switch' statement" section.