### PR TITLE
fix text not corresponding to the code

### DIFF
--- a/1-js/04-object-basics/07-optional-chaining/article.md
+++ b/1-js/04-object-basics/07-optional-chaining/article.md
@@ -166,9 +166,9 @@ userGuest.admin?.(); // nothing (no such method)
 */!*
 ```
 
-Here, in both lines we first use the dot (`user1.admin`) to get `admin` property, because the user object must exist, so it's safe read from it.
+Here, in both lines we first use the dot notion `userAdmin.admin\userGuest.admin` to get `admin` property, because we assume the `userAdmin\userGuest` object must exist, so it's safe read from it.
 
-Then `?.()` checks the left part: if the admin function exists, then it runs (that's so for `user1`). Otherwise (for `user2`) the evaluation stops without errors.
+Then `?.()` checks the left part: if the admin function exists, then it runs (that's so for `userAdmin`). Otherwise (for `userGuest`) the evaluation stops without errors.
 
 The `?.[]` syntax also works, if we'd like to use brackets `[]` to access properties instead of dot `.`. Similar to previous cases, it allows to safely read a property from an object that may not exist.
 


### PR DESCRIPTION
Some text was still for the code example in Russian. (https://learn.javascript.ru/optional-chaining)
Here I just edited the text. Maybe changing code back to Russian version is another good option to fix the error.