### PR TITLE
Clearer CachingDecorator comments

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/article.md
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/article.md
@@ -36,11 +36,11 @@ function cachingDecorator(func) {
 
 slow = cachingDecorator(slow);
 
-alert( slow(1) ); // slow(1) is cached
-alert( "Again: " + slow(1) ); // the same
+alert( slow(1) ); // slow(1) is cached and the result returned
+alert( "Again: " + slow(1) ); // slow(1) result returned from cache
 
-alert( slow(2) ); // slow(2) is cached
-alert( "Again: " + slow(2) ); // the same as the previous line
+alert( slow(2) ); // slow(2) is cached and the result returned
+alert( "Again: " + slow(2) ); // slow(2) result returned from cache
 ```
 
 In the code above `cachingDecorator` is a *decorator*: a special function that takes another function and alters its behavior.


### PR DESCRIPTION
 - comments are in pairs. The first of the pair talks about what
   happened "caching" and the second pair talks about what was
   alerted "the same". This is confusing.
 - changed comment so both lines tell the reader what happened
   and what result was returned.