### PR TITLE
Re-exported symbols not available in current module

### DIFF
--- a/1-js/13-modules/02-import-export/article.md
+++ b/1-js/13-modules/02-import-export/article.md
@@ -362,7 +362,7 @@ export {User};
 
 Now users of our package can `import {login} from "auth/index.js"`.
 
-The syntax `export ... from ...` is just a shorter notation for such import-export:
+The syntax `export ... from ...` is just a shorter notation for such import-export, but note that the symbols do not become available inside the current module.
 
 ```js
 // 📁 auth/index.js


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export#re-exporting_aggregating, "But where function1 and function2 do not become available inside the current module."