### PR TITLE
Fix wrong description about object key type

### DIFF
--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -5,7 +5,7 @@ As we know from the chapter <info:types>, there are eight data types in JavaScri
 
 In contrast, objects are used to store keyed collections of various data and more complex entities. In JavaScript, objects penetrate almost every aspect of the language. So we must understand them first before going in-depth anywhere else.
 
-An object can be created with figure brackets `{…}` with an optional list of *properties*. A property is a "key: value" pair, where `key` is a string (also called a "property name"), and `value` can be anything.
+An object can be created with figure brackets `{…}` with an optional list of *properties*. A property is a "key: value" pair, where `key` is a string or symbol(also called a "property name"), and `value` can be anything.
 
 We can imagine an object as a cabinet with signed files. Every piece of data is stored in its file by the key. It's easy to find a file by its name or add/remove a file.
 


### PR DESCRIPTION
object key can be string or symbol, for example:

```javascript
const symbol = Symbol();
const obj = {};
obj[symbol] = 1;
console.log(obj[symbol]); // 1
console.log(typeof symbol); // 'symbol'
```