### PR TITLE
we can use label and break with simple JavaScript blocks and functions

### DIFF
--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -368,7 +368,7 @@ break label; // doesn't jumps to the label below
 label: for (...)
 ```
 
-If we work with labeled loops, a call to `break/continue` is only possible from inside the loop and the label must be somewhere above the directive.
+When working with a labelled loop, a call to `break/continue` is only possible from inside that loop and the label must be somewhere above the directive.
 ````
 
 ## Summary

--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -368,7 +368,7 @@ break label; // doesn't jumps to the label below
 label: for (...)
 ```
 
-A call to `break/continue` is only possible from inside a loop and the label must be somewhere above the directive.
+If we work with labeled loops, a call to `break/continue` is only possible from inside the loop and the label must be somewhere above the directive.
 ````
 
 ## Summary


### PR DESCRIPTION
Changed line make me think "we can only use label and break/continue with loops". But this is not totally true. We can use label and break with simple JavaScript blocks and function declarations. So, I tried to make it more clear.

[MDN ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label#using_a_labeled_block_with_break)