### PR TITLE
Clarify that primitives passed to functions are copied

### DIFF
--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -154,7 +154,7 @@ showMessage('Ann', "What's up?"); // Ann: What's up? (**)
 
 When the function is called in lines `(*)` and `(**)`, the given values are copied to local variables `from` and `text`. Then the function uses them.
 
-Here's one more example: we have a variable `from` and pass it to the function. Please note: although the function changes `from`, the change is not seen outside out the function. This is because when functions receive primitive data types as arguments, they always get a copy of the value instead:
+Here's one more example: we have a variable `from` and pass it to the function. Please note: although the function changes `from`, the change is not seen outside the function. This is because when functions receive primitive data types as arguments, they always get a copy of the value instead:
 
 
 ```js run

--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -154,7 +154,7 @@ showMessage('Ann', "What's up?"); // Ann: What's up? (**)
 
 When the function is called in lines `(*)` and `(**)`, the given values are copied to local variables `from` and `text`. Then the function uses them.
 
-Here's one more example: we have a variable `from` and pass it to the function. Please note: the function changes `from`, but the change is not seen outside, because a function always gets a copy of the value:
+Here's one more example: we have a variable `from` and pass it to the function. Please note: although the function changes `from`, the change is not seen outside out the function. This is because when functions receive primitive data types as arguments, they always get a copy of the value instead:
 
 
 ```js run

--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -154,7 +154,7 @@ showMessage('Ann', "What's up?"); // Ann: What's up? (**)
 
 When the function is called in lines `(*)` and `(**)`, the given values are copied to local variables `from` and `text`. Then the function uses them.
 
-Here's one more example: we have a variable `from` and pass it to the function. Please note: although the function changes `from`, the change is not seen outside the function. This is because when functions receive primitive data types as arguments, they always get a copy of the value instead:
+Here's one more example: we have a variable `from` and pass it to the function. Please note: although the function changes `from`, the change is not seen outside the function. This is because when functions receive primitive data types as arguments, they always get a copy of the values instead:
 
 
 ```js run


### PR DESCRIPTION
This further clarifies why the variable `from` is not modified outside of the function. Because objects are passed by reference, they can be modified by a function, which is why the current statement can be deceiving.