### PR TITLE
Fix little formatting typo in 1.2.13 (loops)

### DIFF
--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -318,7 +318,7 @@ alert('Done!');
 
 We need a way to stop the process if the user cancels the input.
 
-The ordinary `break` after `input` would only break the inner loop. That's not sufficient--labels, come to the rescue!
+The ordinary `break` after `input` would only break the inner loop. That's not sufficient -- labels, come to the rescue!
 
 A *label* is an identifier with a colon before a loop:
 ```js


### PR DESCRIPTION
On the site it looks like this:

---

(this is a screenshot) ![image](https://user-images.githubusercontent.com/9349164/110060306-6d37f800-7db1-11eb-8386-d8848d3bf46d.png)

---
that obviously reads better with spaces.