### PR TITLE
class syntax vs object literal

### DIFF
--- a/1-js/04-object-basics/04-object-methods/article.md
+++ b/1-js/04-object-basics/04-object-methods/article.md
@@ -90,8 +90,6 @@ user = {
 
 As demonstrated, we can omit `"function"` and just write `sayHi()`.
 
-To tell the truth, the notations are not fully identical. There are subtle differences related to object inheritance (to be covered later), but for now they do not matter. In almost all cases the shorter syntax is preferred.
-
 ## "this" in methods
 
 It's common that an object method needs to access the information stored in the object to do its job.


### PR DESCRIPTION
> To tell the truth, the notations are not fully identical. There are subtle differences related to object inheritance (to be covered later), but for now they do not matter. In almost all cases the shorter syntax is preferred.

I think this paragraph talks about prototypal inheritance but when we work with object literal there is no difference between  `sayHi: function() {` and `sayHi() {`  booth syntaxes add property as own property of object itself, does not add property to object's `prototype` like es6 class syntax.