### PR TITLE
label directive mislabelled

### DIFF
--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -370,7 +370,7 @@ label: for (...)
 
 A call to `continue` is only possible from inside the loop.
 
-The `break` directive may be placed before code blocks too, as `label: { ... }`, but it's almost never used like that. And it also works only inside-out.
+The `label` directive may be placed before code blocks too, as `label: { ... }`, but it's almost never used like that. And it also works only inside-out.
 ````
 
 ## Summary


### PR DESCRIPTION
Line 373: It says 'break' directive but the line itself and the paragraph before are talking about 'label'.