### PR TITLE
domain cookie option

### DIFF
--- a/6-data-storage/01-cookie/article.md
+++ b/6-data-storage/01-cookie/article.md
@@ -98,7 +98,7 @@ A domain defines where the cookie is accessible. In practice though, there are l
 
 **There's no way to let a cookie be accessible from another domain, so `other.com` will never receive a cookie set at `site.com`.**
 
-It's a safety restriction, to allow us to store sensitive data in cookies, that should be available only on one site.
+It's a safety restriction, to allow us to store sensitive data in cookies that should be available only on one site.
 
 By default, a cookie is accessible only at the domain level that set it.
 

--- a/6-data-storage/01-cookie/article.md
+++ b/6-data-storage/01-cookie/article.md
@@ -100,7 +100,7 @@ A domain defines where the cookie is accessible. In practice though, there are l
 
 It's a safety restriction, to allow us to store sensitive data in cookies that should be available only on one site.
 
-By default, a cookie is accessible only at the domain level that set it.
+By default, a cookie is accessible only at the domain that set it.
 
 ...What's tricky, we won't get the cookie at a subdomain `forum.site.com`!
 

--- a/6-data-storage/01-cookie/article.md
+++ b/6-data-storage/01-cookie/article.md
@@ -96,9 +96,13 @@ Usually, we should set `path` to the root: `path=/` to make the cookie accessibl
 
 A domain defines where the cookie is accessible. In practice though, there are limitations. We can't set any domain.
 
-By default, a cookie is accessible only at the domain that set it. So, if the cookie was set by `site.com`, we won't get it at `other.com`.
+**There's no way to let a cookie be accessible from another domain, so `other.com` will never receive a cookie set at `site.com`.**
 
-...But what's more tricky, we also won't get the cookie at a subdomain `forum.site.com`!
+It's a safety restriction, to allow us to store sensitive data in cookies, that should be available only on one site.
+
+By default, a cookie is accessible only at the domain level that set it.
+
+...What's tricky, we won't get the cookie at a subdomain `forum.site.com`!
 
 ```js
 // at site.com
@@ -107,10 +111,6 @@ document.cookie = "user=John"
 // at forum.site.com
 alert(document.cookie); // no user
 ```
-
-**There's no way to let a cookie be accessible from another 2nd-level domain, so `other.com` will never receive a cookie set at `site.com`.**
-
-It's a safety restriction, to allow us to store sensitive data in cookies, that should be available only on one site.
 
 ...But if we'd like to allow subdomains like `forum.site.com` to get a cookie, that's possible. When setting a cookie at `site.com`, we should explicitly set the `domain` option to the root domain: `domain=site.com`:
 

--- a/6-data-storage/01-cookie/article.md
+++ b/6-data-storage/01-cookie/article.md
@@ -96,7 +96,7 @@ Usually, we should set `path` to the root: `path=/` to make the cookie accessibl
 
 A domain defines where the cookie is accessible. In practice though, there are limitations. We can't set any domain.
 
-**There's no way to let a cookie be accessible from another domain, so `other.com` will never receive a cookie set at `site.com`.**
+**There's no way to let a cookie be accessible from another 2nd-level domain, so `other.com` will never receive a cookie set at `site.com`.**
 
 It's a safety restriction, to allow us to store sensitive data in cookies that should be available only on one site.
 


### PR DESCRIPTION
line 111
"no way to let a cookie be accessible from another 2nd-level domain"
you mean
"no way to let a cookie be accessible from another domain" ??

if so, I would also rewrite the "domain" topic something like this.

Moved the most important lines to the top  "other.com never access to..."  
once stated that, no need to refer to "other site" anymore 
and can focus on subdomain tricky part  
