### PR TITLE
Update article.md

### DIFF
--- a/1-js/05-data-types/07-map-set/article.md
+++ b/1-js/05-data-types/07-map-set/article.md
@@ -134,9 +134,6 @@ for (let entry of recipeMap) { // the same as of recipeMap.entries()
 }
 ```
 
-```smart header="The insertion order is used"
-The iteration goes in the same order as the values were inserted. `Map` preserves this order, unlike a regular `Object`.
-```
 
 Besides that, `Map` has a built-in `forEach` method, similar to `Array`:
 


### PR DESCRIPTION
The iteration goes in the same order as the values were inserted in the regular Object as well. Check the below code snippet. The iteration order in regular will be the same like map has.
```
var obj = {};
obj['a'] = 'a';
obj['b'] = 'b';
obj['d'] = 'd';
obj['c'] = 'c';
for ( var t in obj) {
  console.log(t)
}
```