### PR TITLE
Move section about undefined this inside modules

### DIFF
--- a/1-js/13-modules/01-modules-intro/article.md
+++ b/1-js/13-modules/01-modules-intro/article.md
@@ -77,6 +77,19 @@ Modules always `use strict`, by default. E.g. assigning to an undeclared variabl
 </script>
 ```
 
+Because of this inbuilt rule, it's useful to mention that the top-level `this` will be undefined.
+
+Compare it to non-module scripts, where `this` is a global object:
+
+```html run height=0
+<script>
+  alert(this); // window
+</script>
+<script type="module">
+  alert(this); // undefined
+</script>
+```
+
 ### Module-level scope
 
 Each module has its own top-level scope. In other words, top-level variables and functions from a module are not seen in other scripts.

--- a/1-js/13-modules/01-modules-intro/article.md
+++ b/1-js/13-modules/01-modules-intro/article.md
@@ -211,24 +211,6 @@ Its content depends on the environment. In the browser, it contains the url of t
 </script>
 ```
 
-### In a module, "this" is undefined
-
-That's kind of a minor feature, but for completeness we should mention it.
-
-In a module, top-level `this` is undefined.
-
-Compare it to non-module scripts, where `this` is a global object:
-
-```html run height=0
-<script>
-  alert(this); // window
-</script>
-
-<script type="module">
-  alert(this); // undefined
-</script>
-```
-
 ## Browser-specific features
 
 There are also several browser-specific differences of scripts with `type="module"` compared to regular ones.


### PR DESCRIPTION
Move the section about "undefined global this" within the "inbuilt strict mode" one.
This characteristic is not specific to modules but related to the inbuilt use-strict that modules have,
and the way the information was placed could mislead the user to think that it was module-exclusive.