### PR TITLE
not a handler -pls check gramm

### DIFF
--- a/2-ui/5-loading/01-onload-ondomcontentloaded/article.md
+++ b/2-ui/5-loading/01-onload-ondomcontentloaded/article.md
@@ -45,7 +45,7 @@ For instance:
 <img id="img" src="https://en.js.cx/clipart/train.gif?speed=1&cache=0">
 ```
 
-In the example the `DOMContentLoaded` handler runs when the document is loaded, so it can see all the elements, including `<img>` below.
+In the example the `DOMContentLoaded`'s handler runs when the document is loaded, so it can see all the elements, including `<img>` below.
 
 But it doesn't wait for the image to load. So `alert` shows zero sizes.
 


### PR DESCRIPTION
"DOMContentLoaded handler" suggests "handler named DOMContentLoaded".
Is allowed  "DOMContentLoaded's handler " ?
maybe  " the handler of DOMContentLoaded " 
