### PR TITLE
 FIX: The range of hexadecimal numbers is 0-9 or A-F

### DIFF
--- a/9-regular-expressions/03-regexp-unicode/article.md
+++ b/9-regular-expressions/03-regexp-unicode/article.md
@@ -107,7 +107,7 @@ Unicode supports many different properties, their full list would require a lot 
 
 ### Example: hexadecimal numbers
 
-For instance, let's look for hexadecimal numbers, written as `xFF`, where `F` is a hex digit (0..1 or A..F).
+For instance, let's look for hexadecimal numbers, written as `xFF`, where `F` is a hex digit (0..9 or A..F).
 
 A hex digit can be denoted as `pattern:\p{Hex_Digit}`:
 


### PR DESCRIPTION
The range of hexadecimal numbers is 0-9 or A-F not 0-1 or A-F.