### PR TITLE
fix bug in a task solution in weakmap-weakset

### DIFF
--- a/1-js/05-data-types/08-weakmap-weakset/01-recipients-read/solution.md
+++ b/1-js/05-data-types/08-weakmap-weakset/01-recipients-read/solution.md
@@ -34,7 +34,7 @@ Another, different solution could be to add a property like `message.isRead=true
 Like this:
 ```js
 // the symbolic property is only known to our code
-let isRead = Symbol("isRead");
+let isRead = Symbol.for("isRead");
 messages[0][isRead] = true;
 ```
 


### PR DESCRIPTION
Hi, in my humble opinion a global symbol should be used here, because when we check the isRead status for all messages, they should exist under the same secret key.

I could be totally wrong because I'm not very good at symbols, feel free to reject.