### PR TITLE
(2nd try) improve clarity of Promise.all()

### DIFF
--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -18,7 +18,7 @@ let promise = Promise.all([...promises...]);
 
 `Promise.all` takes an array of promises (it technically can be any iterable, but is usually an array) and returns a new promise.
 
-The new promise resolves when all listed promises are settled, and the array of their results becomes its result.
+The new promise resolves if all listed promises are resolved, and the array of their results becomes its result.
 
 For instance, the `Promise.all` below settles after 3 seconds, and then its result is an array `[1, 2, 3]`:
 


### PR DESCRIPTION
The original version was inaccurate because:
1. "settle" means "either resolve or reject" (think`Promise.allSettled`)
2. `Promise.all()` does not necessarily _resolve_ when all promises are _settled_.