### PR TITLE
Added a missing explanation

### DIFF
--- a/2-ui/2-events/01-introduction-browser-events/article.md
+++ b/2-ui/2-events/01-introduction-browser-events/article.md
@@ -179,14 +179,19 @@ button.onclick = function() {
 };
 ```
 
-**Don't use `setAttribute` for handlers.**
+**While using `setAttribute` for handlers.**
 
 Such a call won't work:
 
 ```js run no-beautify
 // a click on <body> will generate errors,
-// because attributes are always strings, function becomes a string
+// because attributes are always strings
 document.body.setAttribute('onclick', function() { alert(1) });
+```
+But we can make this work by passing the function expression as a string
+
+```js run no-beautify
+document.body.setAttribute('onclick', "function() { alert(1) }");
 ```
 
 **DOM-property case matters.**


### PR DESCRIPTION
It is mentioned that we should not use `setAttribute` for registering handlers. But it is possible to use `setAttribute` for registering handlers if we pass the function expression as a string. Requesting proper explanation for the statement **Don't use `setAttribute` for handlers** in the tutorial if the claim was flawless.