### PR TITLE
Update prop descriptors article

### DIFF
--- a/1-js/07-object-properties/01-property-descriptors/article.md
+++ b/1-js/07-object-properties/01-property-descriptors/article.md
@@ -225,7 +225,7 @@ To be precise, non-configurability imposes several restrictions on `defineProper
 1. Can't change `configurable` flag.
 2. Can't change `enumerable` flag.
 3. Can't change `writable: false` to `true` (the other way round works).
-4. Can't change `get/set` for an accessor property (but can assign them if absent).
+4. Can't change `get/set` for an accessor property.
 
 **The idea of "configurable: false" is to prevent changes of property flags and its deletion, while allowing to change its value.**
 


### PR DESCRIPTION
Deletes info that it's possible to assign get/set for non-configurable accessor property if absent.

Maybe I just misunderstood. Could you please add some example about it if I'm wrong.

Please check this example.
https://codepen.io/artemtropanets/pen/bGqPKYx
If we have only a getter before setting 'configurable' to 'false' - then setter is 'undefined' and it's not possible to overwrite it later.
If we don't have get/set before changing 'configurable' then it's data property and it's not possible to change it to accessor property.