### PR TITLE
Response header name is changed to the right one

### DIFF
--- a/5-network/06-fetch-api/article.md
+++ b/5-network/06-fetch-api/article.md
@@ -147,7 +147,7 @@ This option may be useful when the URL for `fetch` comes from a 3rd-party, and w
 The `credentials` option specifies whether `fetch` should send cookies and HTTP-Authorization headers with the request.
 
 - **`"same-origin"`** -- the default, don't send for cross-origin requests,
-- **`"include"`** -- always send, requires `Accept-Control-Allow-Credentials` from cross-origin server in order for JavaScript to access the response, that was covered in the chapter <info:fetch-crossorigin>,
+- **`"include"`** -- always send, requires `Access-Control-Allow-Credentials` from cross-origin server in order for JavaScript to access the response, that was covered in the chapter <info:fetch-crossorigin>,
 - **`"omit"`** -- never send, even for same-origin requests.
 
 ## cache


### PR DESCRIPTION
According to Wikipedia, there doesn't exist a header with a name "Accept-Control-Allow-Credentials". There is only one header that has similar name "Access-Control-Allow-Credentials". It seems to be exactly what was meant initally. By the way, it is mentioned in previous chapters as well. So it appears to be quite reasonable to fix that typo if I'm not mistaken. 