### PR TITLE
Fixed a simple grammatical error

### DIFF
--- a/1-js/11-async/01-callbacks/article.md
+++ b/1-js/11-async/01-callbacks/article.md
@@ -10,7 +10,7 @@ If you're not familiar with these methods, and their usage in the examples is co
 Although, we'll try to make things clear anyway. There won't be anything really complex browser-wise.
 ```
 
-Many functions are provided by JavaScript host environments that allow you to schedule *asynchronous* actions. In other words, actions that we initiate now, but they finish later.
+Many functions are provided by JavaScript host environments that allow you to schedule *asynchronous* actions. In other words, actions that we initiate now, but finish later.
 
 For instance, one such function is the `setTimeout` function.
 


### PR DESCRIPTION
I fixed a simple grammatical error that was present on the 11.1 Introduction: callbacks page
https://javascript.info/callbacks 