### PR TITLE
Fixing the unintentional behavior of the slider

### DIFF
--- a/2-ui/3-event-details/6-pointer-events/slider.view/index.html
+++ b/2-ui/3-event-details/6-pointer-events/slider.view/index.html
@@ -8,16 +8,20 @@
 <script>
   let thumb = slider.querySelector('.thumb');
   let shiftX;
-
+  let mainPointer;
+  
   thumb.onpointerdown = function(event) {
     event.preventDefault(); // prevent selection start (browser action)
 
     shiftX = event.clientX - thumb.getBoundingClientRect().left;
-
-    thumb.setPointerCapture(event.pointerId);
+    
+    mainPointer = event.pointerId;
+    thumb.setPointerCapture(mainPointer);
   };
 
   thumb.onpointermove = function(event) {
+    if (event.pointerId !== mainPointer) return;
+    
     let newLeft = event.clientX - shiftX - slider.getBoundingClientRect().left;
 
     // if the pointer is out of slider => adjust left to be within the bounaries
@@ -33,5 +37,9 @@
   };
 
   thumb.ondragstart = () => false;
+  
+  thumb.onlostpointercapture = function(event) {
+    mainPointer = null;
+  };
 
 </script>


### PR DESCRIPTION
When reading the article "Pointer events", I came across just a small bug.  When the pointer capture is set to the thumb, all consequent events including "pointermove" are retargeted back to the thumb. However, when the capture is lost, event listener for "pointermove" remains installed on the thumb element.  As a result, we can move inadvertently that thumb when we simply moving our mouse over it. To prevent its unintentional behavior, I suggest that we store capture pointer's id in a separate variable as long as capture persists.