### PR TITLE
current origin meaning

### DIFF
--- a/6-data-storage/03-indexeddb/article.md
+++ b/6-data-storage/03-indexeddb/article.md
@@ -37,7 +37,7 @@ let openRequest = indexedDB.open(name, version);
 - `name` -- a string, the database name.
 - `version` -- a positive integer version, by default `1` (explained below).
 
-We can have many databases with different names, but all of them exist within the current origin (domain/protocol/port). Different websites can't access each other's databases.
+A database is bound to its origin forever. We can have many databases with different names, but all of them exist within the current origin (domain/protocol/port). Different websites can't access each other's databases.
 
 The call returns `openRequest` object, we should listen to events on it:
 - `success`: database is ready, there's the "database object" in `openRequest.result`, we should use it for further calls.


### PR DESCRIPTION
or something

I remember my first dumb idea of having a local html backup to access my db while offline and sync with origin when online (I learn the impossibility when I realized the security issue. Btw, pinning the webpage in chrome works.)

here I read this line "current origin" and "different sites cant access each other dbs" 
with "current" I see an open door "not now". 
I thought it's a good place to make a strong statement, it is not that evident if you miss cross-origin articles... 
