### PR TITLE
Update article.md

### DIFF
--- a/1-js/01-getting-started/3-code-editors/article.md
+++ b/1-js/01-getting-started/3-code-editors/article.md
@@ -32,7 +32,6 @@ In practice, lightweight editors may have a lot of plugins including directory-l
 The following options deserve your attention:
 
 - [Atom](https://atom.io/) (cross-platform, free).
-- [Visual Studio Code](https://code.visualstudio.com/) (cross-platform, free).
 - [Sublime Text](http://www.sublimetext.com) (cross-platform, shareware).
 - [Notepad++](https://notepad-plus-plus.org/) (Windows, free).
 - [Vim](http://www.vim.org/) and [Emacs](https://www.gnu.org/software/emacs/) are also cool if you know how to use them.


### PR DESCRIPTION
Visual Studio Code has been introduced as an "IDE", so it should no longer appear under "Lightweight editors"