### PR TITLE
fix(ui/events-change-input): copy & cut events

### DIFF
--- a/2-ui/4-forms-controls/3-events-change-input/article.md
+++ b/2-ui/4-forms-controls/3-events-change-input/article.md
@@ -67,10 +67,14 @@ For instance, the code below prevents all such events and shows what we are tryi
 ```html autorun height=40 run
 <input type="text" id="input">
 <script>
-  input.oncut = input.oncopy = input.onpaste = function(event) {
+  input.onpaste = function(event) {
     alert(event.type + ' - ' + event.clipboardData.getData('text/plain'));
-    return false;
+    return false; // false prevents changes
   };
+  input.oncut = input.oncopy = function(event) {
+    alert(event.type + '-' + document.getSelection());
+    return false; // false prevents changes
+  }
 </script>
 ```
 


### PR DESCRIPTION
Related issues: #2738, javascript-tutorial/zh.javascript.info#956