### PR TITLE
"for" block

### DIFF
--- a/1-js/06-advanced-functions/03-closure/article.md
+++ b/1-js/06-advanced-functions/03-closure/article.md
@@ -69,7 +69,7 @@ alert(message);
 ```
 ````
 
-For `if`, `for`, `while` and so on, variables declared in `{...}` are also only visible inside:
+`if`, `for`, `while` and so on are blocks themselves. Variables declared inside them are not visible outside:
 
 ```js run
 if (true) {
@@ -96,7 +96,7 @@ for (let i = 0; i < 3; i++) {
 alert(i); // Error, no such variable
 ```
 
-Visually, `let i` is outside of `{...}`. But the `for` construct is special here: the variable, declared inside it, is considered a part of the block.
+Visually, `let i` is outside of `{...}`. But the variable `i` was declared inside the `for` block construct.
 
 ## Nested functions
 


### PR DESCRIPTION
I dont like my writting, but.

why. Consider 
```
for ( let i=1;;)  i++ ;     // no brackets, still hidden from the outside
for ( let i ; i<1  ;  i++, j="" ) {  let j ; ... }   //  err, block inside block (couldnt test wo brackts  )
```
nothing "special" about it. It behaves 
{for ( ){ } }

something similar in while for / label article
you dont label a line to jump to,
you label the for block you want to escape from.
label: { for ( ){ } }