### PR TITLE
fix the broken RFC link

### DIFF
--- a/5-network/11-websocket/article.md
+++ b/5-network/11-websocket/article.md
@@ -1,6 +1,6 @@
 # WebSocket
 
-The `WebSocket` protocol, described in the specification [RFC 6455](http://tools.ietf.org/html/rfc6455) provides a way to exchange data between browser and server via a persistent connection. The data can be passed in both directions as "packets", without breaking the connection and additional HTTP-requests.
+The `WebSocket` protocol, described in the specification [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455) provides a way to exchange data between browser and server via a persistent connection. The data can be passed in both directions as "packets", without breaking the connection and additional HTTP-requests.
 
 WebSocket is especially great for services that require continuous data exchange, e.g. online games, real-time trading systems and so on.
 


### PR DESCRIPTION
The original URL http://tools.ietf.org/html/rfc6455 is broken, return a 404 status code. Refresh it to the new URL https://datatracker.ietf.org/doc/html/rfc6455.