### PR TITLE
Clarify that generators are both iterator and iterable

### DIFF
--- a/1-js/12-generators-iterators/1-generators/article.md
+++ b/1-js/12-generators-iterators/1-generators/article.md
@@ -40,7 +40,7 @@ The function code execution hasn't started yet:
 
 ![](generateSequence-1.svg)
 
-The main method of a generator is `next()`. When called, it runs the execution until the nearest `yield <value>` statement (`value` can be omitted, then it's `undefined`). Then the function execution pauses, and the yielded `value` is returned to the outer code.
+The main method of a generator is `next()`, which implies that a generator is *iterator*. When `next()`, it runs the execution until the nearest `yield <value>` statement (`value` can be omitted, then it's `undefined`). Then the function execution pauses, and the yielded `value` is returned to the outer code.
 
 The result of `next()` is always an object with two properties:
 - `value`: the yielded value.
@@ -100,7 +100,7 @@ But usually the first syntax is preferred, as the star `*` denotes that it's a g
 
 ## Generators are iterable
 
-As you probably already guessed looking at the `next()` method, generators are [iterable](info:iterable).
+Generators are not only iterator but also [iterable](info:iterable).
 
 We can loop over their values using `for..of`:
 

--- a/1-js/12-generators-iterators/1-generators/article.md
+++ b/1-js/12-generators-iterators/1-generators/article.md
@@ -40,7 +40,7 @@ The function code execution hasn't started yet:
 
 ![](generateSequence-1.svg)
 
-The main method of a generator is `next()`, which implies that a generator is *iterator*. When `next()`, it runs the execution until the nearest `yield <value>` statement (`value` can be omitted, then it's `undefined`). Then the function execution pauses, and the yielded `value` is returned to the outer code.
+The main method of a generator is `next()`, which implies that a generator is *iterator*. When `next()` is called, it runs the execution until the nearest `yield <value>` statement (`value` can be omitted, then it's `undefined`). Then the function execution pauses, and the yielded `value` is returned to the outer code.
 
 The result of `next()` is always an object with two properties:
 - `value`: the yielded value.


### PR DESCRIPTION
The fact that a generator object is iterable, has nothing to do with it
having the `next()` method. It is according to the [spec][1]:
A generator object is *both* iterator and iterable.

I try to introduce change as small as possible, but I wish that
iteration protocols are explicitly mentioned somewhere.

[1]: https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator-objects