### PR TITLE
fix the broken RFC link in the JSON article

### DIFF
--- a/1-js/05-data-types/12-json/article.md
+++ b/1-js/05-data-types/12-json/article.md
@@ -27,7 +27,7 @@ Luckily, there's no need to write the code to handle all this. The task has been
 
 ## JSON.stringify
 
-The [JSON](http://en.wikipedia.org/wiki/JSON) (JavaScript Object Notation) is a general format to represent values and objects. It is described as in [RFC 4627](http://tools.ietf.org/html/rfc4627) standard. Initially it was made for JavaScript, but many other languages have libraries to handle it as well.  So it's easy to use JSON for data exchange when the client uses JavaScript and the server is written on Ruby/PHP/Java/Whatever.
+The [JSON](http://en.wikipedia.org/wiki/JSON) (JavaScript Object Notation) is a general format to represent values and objects. It is described as in [RFC 4627](https://tools.ietf.org/html/rfc4627) standard. Initially it was made for JavaScript, but many other languages have libraries to handle it as well.  So it's easy to use JSON for data exchange when the client uses JavaScript and the server is written on Ruby/PHP/Java/Whatever.
 
 JavaScript provides methods:
 


### PR DESCRIPTION
In the JSON article, a link leads to an 404 page. Changing http to https makes the link redirect to the correct page instead.
**http**://tools.ietf.org/html/rfc4627 => **https**://tools.ietf.org/html/rfc4627

Same problem as https://github.com/javascript-tutorial/en.javascript.info/pull/2781 that was applied on the websocket page.  
I looked for all the pages with a link to ietf.org and they will all be OK now : 
https://javascript.info/json
https://javascript.info/cookie
https://javascript.info/websocket