### PR TITLE
fix: changed 'within' to 'without'

### DIFF
--- a/2-ui/1-document/10-size-and-scroll-window/article.md
+++ b/2-ui/1-document/10-size-and-scroll-window/article.md
@@ -29,7 +29,7 @@ alert( window.innerWidth ); // full window width
 alert( document.documentElement.clientWidth ); // window width minus the scrollbar
 ```
 
-In most cases, we need the *available* window width in order to draw or position something within scrollbars (if there are any), so we should use `documentElement.clientHeight/clientWidth`.
+In most cases, we need the *available* window width in order to draw or position something without scrollbars (if there are any), so we should use `documentElement.clientHeight/clientWidth`.
 ````
 
 ```warn header="`DOCTYPE` is important"


### PR DESCRIPTION
I think here was meant 'without' instead of 'within'. Because `documentElement.clientHeight/clientWidth` methods get size without scrollbars.