### PR TITLE
Correction to Part I - 14.2 "Eval"

### DIFF
--- a/1-js/99-js-misc/02-eval/article.md
+++ b/1-js/99-js-misc/02-eval/article.md
@@ -59,7 +59,7 @@ In strict mode, `eval` has its own lexical environment. So functions and variabl
 ```js untrusted refresh run
 // reminder: 'use strict' is enabled in runnable examples by default
 
-eval("let x = 5; function f() {}");
+eval("var x = 5; function f() {}");
 
 alert(typeof x); // undefined (no such variable)
 // function f is also not visible


### PR DESCRIPTION
I think there's a mistake in a code snippet which illustrates usage of `eval` in strict mode. As `let` creates a block scope variable, such a variable won't be visible neither in strict mode, nor in sloppy mode. A `var` should be used instead.