### PR TITLE
Add "us" for grammatical reasons 

### DIFF
--- a/1-js/02-first-steps/16-function-expressions/article.md
+++ b/1-js/02-first-steps/16-function-expressions/article.md
@@ -12,7 +12,7 @@ function sayHi() {
 
 There is another syntax for creating a function that is called a *Function Expression*.
 
-It allows to create a new function in the middle of any expression.
+It allows us to create a new function in the middle of any expression.
 
 For example:
 


### PR DESCRIPTION
It allows [us] to create a new function in the middle of any expression.