### PR TITLE
Add alternative solution for throttle decorator task on article "Decorators and forwarding, call/apply"

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/04-throttle/solution.md
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/04-throttle/solution.md
@@ -36,3 +36,30 @@ A call to `throttle(func, ms)` returns `wrapper`.
 3. After `ms` milliseconds pass, `setTimeout` triggers. The cooldown state is removed (`isThrottled = false`) and, if we had ignored calls, `wrapper` is executed with the last memorized arguments and context.
 
 The 3rd step runs not `func`, but `wrapper`, because we not only need to execute `func`, but once again enter the cooldown state and setup the timeout to reset it.
+
+## Alternative solution:
+
+```javascript
+function throttle(func, ms) {
+  let nextRun, timeout;
+
+  function wrapper () {
+    if (!nextRun || nextRun < Date.now()) {
+      func.apply(this, arguments); // (*)
+      nextRun = Date.now() + ms;
+    } else {
+      let tillNextRun = nextRun - Date.now(); // (**)
+      clearTimeout(timeout); 
+      timeout = setTimeout(() => { 
+        func.apply(this, arguments);
+        nextRun = Date.now() + ms;
+      }, tillNextRun);
+    }
+  };
+
+  return wrapper;
+}
+```
+
+1. During the first call, the `nextRun` is `undefined` so the `wrapper` enters `if` block `(*)`, runs `func` and sets the `nextRun` to `ms` milliseconds from that moment ( `nextRun = Date.now() + ms` ).
+2. At subsequent calls, the `nextRun` is defined, so comparing its value with the current timestamp ( `nextRun < Date.now()` ) determines whether the call should be passed to `func` immediately `(*)` or it should be scheduled `(**)`. Please note that on the scheduling path `(**)`, the first step is clearing the previously scheduled call so that only the last call during throttling will be passed to `func`. Also, note that `nextRun` value should be updated only when the call is actually passed to `func` (not after `if else` statement).


### PR DESCRIPTION
This alternative solution for the ["throttle decorator"](https://javascript.info/call-apply-decorators#throttle-decorator) has similar look to the solution for the "Debounce" task, and probably will be easier to grasp, especially for new learners.