### PR TITLE
Minor fix

### DIFF
--- a/1-js/07-object-properties/01-property-descriptors/article.md
+++ b/1-js/07-object-properties/01-property-descriptors/article.md
@@ -318,7 +318,7 @@ for (let key in user) {
 
 ...But that does not copy flags. So if we want a "better" clone then `Object.defineProperties` is preferred.
 
-Another difference is that `for..in` ignores symbolic properties, but `Object.getOwnPropertyDescriptors` returns *all* property descriptors including symbolic ones.
+Another difference is that `for..in` ignores symbolic and non-enumerable properties, but `Object.getOwnPropertyDescriptors` returns *all* property descriptors including symbolic and non-enumerable ones.
 
 ## Sealing an object globally
 


### PR DESCRIPTION
The last sentence of [object-getownpropertydescriptors](https://javascript.info/property-descriptors#object-getownpropertydescriptors) section, indicates that `for..in` ignores symbolic properties while `Object.getOwnPropertyDescriptors` doesn't. The same is true for `non-enumerable` properties, so I think it would be better to add it too.