### PR TITLE
Update unary + (plus) operator precedence explanation

### DIFF
--- a/1-js/02-first-steps/08-operators/article.md
+++ b/1-js/02-first-steps/08-operators/article.md
@@ -205,7 +205,7 @@ Here's an extract from the [precedence table](https://developer.mozilla.org/en-U
 | 3 | assignment | `=` |
 | ... | ... | ... |
 
-As we can see, the "unary plus" has a priority of `17` which is higher than the `13` of "addition" (binary plus). That's why, in the expression `"+apples + +oranges"`, unary pluses work before the addition.
+As we can see, the "unary plus" has a priority of `17` which is higher than the `13` of "addition" (binary plus). That's why, in the expression `+apples + +oranges`, unary pluses work before the addition.
 
 ## Assignment
 


### PR DESCRIPTION
Remove the double quotes in the explanation for unary + (plus) operator precedence so that readers do not potentially misinterpret the entire expression as a string.