### PR TITLE
Fix misleading statement

### DIFF
--- a/2-ui/4-forms-controls/2-focus-blur/article.md
+++ b/2-ui/4-forms-controls/2-focus-blur/article.md
@@ -171,7 +171,7 @@ The example above doesn't work, because when user focuses on an `<input>`, the `
 
 There are two solutions.
 
-First, there's a funny historical feature: `focus/blur` do not bubble up, but propagate down on the capturing phase.
+First, we can handle `focus/blur` events during the capturing phase.
 
 This will work:
 


### PR DESCRIPTION
From the current wording it may seem that the historical feature is the ability of `focus/blur` events to propagate down on the capturing phase. Since all JavaScript events go through the capturing phase, I want to suggest using a more unambiguous wording.