### PR TITLE
Check input to be an Array before using Array.map

### DIFF
--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -182,6 +182,8 @@ if (!Promise.allSettled) {
   const resolveHandler = value => ({ status: 'fulfilled', value });
 
   Promise.allSettled = function (promises) {
+    if (!Array.isArray(promises)) 
+    promises = Array.from(promises);
     const convertedPromises = promises.map(p => Promise.resolve(p).then(resolveHandler, rejectHandler));
     return Promise.all(convertedPromises);
   };


### PR DESCRIPTION
As the beginning of [Promise API](https://javascript.info/promise-api) article mentions that technically the input should be iterable, then in the polyfill section, we should assume the same. So, we need to check the input type using `Array.isArray(promises)` or `promises instanceof Array` before using `Array.map()` or use it with `call` or `apply` method.