### PR TITLE
Fix LI content numbers

### DIFF
--- a/2-ui/1-document/04-searching-elements-dom/article.md
+++ b/2-ui/1-document/04-searching-elements-dom/article.md
@@ -154,7 +154,7 @@ For instance:
 <div class="contents">
   <ul class="book">
     <li class="chapter">Chapter 1</li>
-    <li class="chapter">Chapter 1</li>
+    <li class="chapter">Chapter 2</li>
   </ul>
 </div>
 


### PR DESCRIPTION
I think this is more convenient. If one will call `chapter.closest('.chapter')` they will understand that it returns the first `<li class="chapter">`