### PR TITLE
Update Optional Chaining article.md

### DIFF
--- a/1-js/04-object-basics/07-optional-chaining/article.md
+++ b/1-js/04-object-basics/07-optional-chaining/article.md
@@ -210,7 +210,7 @@ It's just not that smart.
 The optional chaining `?.` syntax has three forms:
 
 1. `obj?.prop` -- returns `obj.prop` if `obj` exists, otherwise `undefined`.
-2. `obj?.[prop]` -- returns `obj[prop]` if `obj` exists, otherwise `undefined`.
+2. `obj?.[prop]` -- returns `obj[prop]` if `obj.property` exists, otherwise `undefined`.
 3. `obj.method?.()` -- calls `obj.method()` if `obj.method` exists, otherwise returns `undefined`.
 
 As we can see, all of them are straightforward and simple to use. The `?.` checks the left part for `null/undefined` and allows the evaluation to proceed if it's not so.


### PR DESCRIPTION
`obj` instead of `obj.property` in Optional chaining syntax explanation 