### PR TITLE
propose additional context for removeEventListener

### DIFF
--- a/2-ui/2-events/01-introduction-browser-events/article.md
+++ b/2-ui/2-events/01-introduction-browser-events/article.md
@@ -433,6 +433,46 @@ The method `handleEvent` does not have to do all the job by itself. It can call 
 
 Now event handlers are clearly separated, that may be easier to support.
 
+````warn header="removeEventListener needs to reference object handler if addEventlistener did."
+As mentioned previously, removal requires the same functional reference as its preceded eventListener arguments. In the instance of object handler, the passing of the same object reference for removeEventListener is required. 
+
+```js no-beautify
+<button id="elem">Click me</button>
+<button id="helperElem">Remove listeners</button>
+<script>
+  class Menu {
+		handleEvent(event) {...}
+		// ....
+  }
+
+  let menu = new Menu(); 
+  elem.addEventListener('mousedown', menu);
+  elem.addEventListener('mouseup', menu);
+	
+	helperElem.onclick = function(event) {
+		elem.removeEventListener('mousedown', menu);
+		elem.removeEventListener('mouseup', menu);
+	})
+	
+</script>
+```
+
+Our reference is tied to the instance of Menu that is `let menu = new Menu()`.  Calling the internal function directly would be a mismatch even if addEventListener internally calls handleEvent.
+
+```js
+<script>  
+	let menu = new Menu(); 
+	  elem.addEventListener('mousedown', menu);
+	  elem.addEventListener('mouseup', menu);
+		
+	helperElem.onclick = function(event) {
+			elem.removeEventListener('mousedown', menu.handleEvent);
+			elem.removeEventListener('mouseup', menu.handleEvent);
+		})
+</script>
+```
+````
+
 ## Summary
 
 There are 3 ways to assign event handlers:


### PR DESCRIPTION
Added a clarification and example for removeEventListener matching on eventListeners initialized with object handler. 
Previously a section mentions 'Removal requires the same **function**'. In the case of object handling, it is the object reference matters here.

demo:
https://jsfiddle.net/op5hjw47/20/