### PR TITLE
replacement the word with more appropriate term

### DIFF
--- a/1-js/05-data-types/02-number/article.md
+++ b/1-js/05-data-types/02-number/article.md
@@ -397,7 +397,7 @@ A few examples:
     ```js run
     alert( Math.random() ); // 0.1234567894322
     alert( Math.random() ); // 0.5435252343232
-    alert( Math.random() ); // ... (any random numbers)
+    alert( Math.random() ); // ... (any pseudorandom  number)
     ```
 
 `Math.max(a, b, c...)` / `Math.min(a, b, c...)`


### PR DESCRIPTION
Perhaps it would be more correct

A Wikipedia article could be attached to the term `Pseudorandom number` ( this is not necessary but as an option ) 

https://en.wikipedia.org/wiki/Pseudorandomness