### PR TITLE
Date task solution: use standard date time string

### DIFF
--- a/1-js/05-data-types/11-date/1-new-date/solution.md
+++ b/1-js/05-data-types/11-date/1-new-date/solution.md
@@ -13,6 +13,6 @@ We could also create a date from a string, like this:
 
 ```js run
 //new Date(datastring)
-let d2 = new Date("February 20, 2012 03:12:00");
+let d2 = new Date("2012-02-20T03:12");
 alert( d2 );
 ```


### PR DESCRIPTION
The Date article only explains standard strings for date parsing.
Non-standard strings are implementation dependent and should
not be used.