### PR TITLE
change syntax `JSON.stringify(value, replacer, space)`

### DIFF
--- a/1-js/05-data-types/12-json/article.md
+++ b/1-js/05-data-types/12-json/article.md
@@ -178,7 +178,7 @@ Here, the conversion fails, because of circular reference: `room.occupiedBy` ref
 The full syntax of `JSON.stringify` is:
 
 ```js
-let json = JSON.stringify(value[, replacer, space])
+let json = JSON.stringify(value, replacer, space)
 ```
 
 value


### PR DESCRIPTION
According to mdn 

![image](https://user-images.githubusercontent.com/73550760/160377951-d79e1745-4b14-4c68-af4c-f49249cf3b70.png)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

If this PR is accepted, it will be possible to close this

https://github.com/javascript-tutorial/en.javascript.info/pull/2889