### PR TITLE
Fix grammar in 'Symbol type' article

### DIFF
--- a/1-js/04-object-basics/08-symbol/article.md
+++ b/1-js/04-object-basics/08-symbol/article.md
@@ -238,7 +238,7 @@ alert( Symbol.keyFor(sym2) ); // id
 
 The `Symbol.keyFor` internally uses the global symbol registry to look up the key for the symbol. So it doesn't work for non-global symbols. If the symbol is not global, it won't be able to find it and returns `undefined`.
 
-That said, any symbols have `description` property.
+That said, all symbols have the `description` property.
 
 For instance:
 


### PR DESCRIPTION
New: That said, all symbols have the `description` property.
Old:   That said, any symbols have `description` property.