### PR TITLE
update localStorage size limit info

### DIFF
--- a/6-data-storage/02-localstorage/article.md
+++ b/6-data-storage/02-localstorage/article.md
@@ -6,7 +6,7 @@ What's interesting about them is that the data survives a page refresh (for `ses
 
 We already have cookies. Why additional objects?
 
-- Unlike cookies, web storage objects are not sent to server with each request. Because of that, we can store much more. Most browsers allow at least 2 megabytes of data (or more) and have settings to configure that.
+- Unlike cookies, web storage objects are not sent to server with each request. Because of that, we can store much more. Most modern browsers allow at least 5 megabytes of data (or more) and have settings to configure that.
 - Also unlike cookies, the server can't manipulate storage objects via HTTP headers. Everything's done in JavaScript.
 - The storage is bound to the origin (domain/protocol/port triplet). That is, different protocols or subdomains infer different storage objects, they can't access data from each other.
 


### PR DESCRIPTION
I think it's safe now to assume that localStorage can store at least 5MB of data since the last time the 2MB limit was mentioned was in 2015 for Android Browser v4, which has a reported global usage of 0.36% according to caniuse.com. Its' current version of 100 seems to support the same 5MB standard