### PR TITLE
Form events navigator.clipboard API Firefox support

### DIFF
--- a/2-ui/4-forms-controls/3-events-change-input/article.md
+++ b/2-ui/4-forms-controls/3-events-change-input/article.md
@@ -101,7 +101,7 @@ Even if someone decides to save `event.clipboardData` in an event handler, and t
 
 To reiterate, [event.clipboardData](https://www.w3.org/TR/clipboard-apis/#clipboardevent-clipboarddata) works solely in the context of user-initiated event handlers.
 
-On the other hand, [navigator.clipboard](https://www.w3.org/TR/clipboard-apis/#h-navigator-clipboard) is the more recent API, meant for use in any context. It asks for user permission, if needed. Not supported in Firefox.
+On the other hand, [navigator.clipboard](https://www.w3.org/TR/clipboard-apis/#h-navigator-clipboard) is the more recent API, meant for use in any context. It asks for user permission, if needed.
 
 ## Summary
 


### PR DESCRIPTION
Stated that navigator.clipboard API is not compatible in Firefox but it is: https://caniuse.com/mdn-api_navigator_clipboard