### PR TITLE
Add a link for missing knowledge

### DIFF
--- a/1-js/11-async/01-callbacks/article.md
+++ b/1-js/11-async/01-callbacks/article.md
@@ -87,7 +87,7 @@ loadScript('/my/script.js', function() {
 });
 ```
 
-That's the idea: the second argument is a function (usually anonymous) that runs when the action is completed.
+That's the idea: the second argument is a function (usually anonymous) that runs when the action is completed. To understand `onload` read [Document and resource loading](/onload-onerror#loading-a-script).
 
 Here's a runnable example with a real script:
 


### PR DESCRIPTION
The article references some concepts from later tutorials which therefore the reader is unlikely to have read yet. A simple reference for where exactly to look is helpful.