### PR TITLE
Fix grammar and phrasing

### DIFF
--- a/1-js/11-async/02-promise-basics/article.md
+++ b/1-js/11-async/02-promise-basics/article.md
@@ -237,7 +237,7 @@ new Promise((resolve, reject) => {
 That said, `finally(f)` isn't exactly an alias of `then(f,f)` though. There are few subtle differences:
 
 1. A `finally` handler has no arguments. In `finally` we don't know whether the promise is successful or not. That's all right, as our task is usually to perform "general" finalizing procedures.
-2. A `finally` handler passes through results and errors to the next handler.
+2. A `finally` handler "passes" the result or error further to subsequent handlers.
 
     For instance, here the result is passed through `finally` to `then`:
     ```js run

--- a/1-js/11-async/02-promise-basics/article.md
+++ b/1-js/11-async/02-promise-basics/article.md
@@ -237,7 +237,7 @@ new Promise((resolve, reject) => {
 That said, `finally(f)` isn't exactly an alias of `then(f,f)` though. There are few subtle differences:
 
 1. A `finally` handler has no arguments. In `finally` we don't know whether the promise is successful or not. That's all right, as our task is usually to perform "general" finalizing procedures.
-2. A `finally` handler "passes" the result or error further to subsequent handlers.
+2. A `finally` handler "passes through" the result or error to the next handler.
 
     For instance, here the result is passed through `finally` to `then`:
     ```js run


### PR DESCRIPTION
_or_
2. A `finally` handler "passes through" the result or error further to subsequent handlers.