### PR TITLE
Several fixes for number type

### DIFF
--- a/1-js/02-first-steps/05-types/article.md
+++ b/1-js/02-first-steps/05-types/article.md
@@ -68,7 +68,7 @@ We'll see more about working with numbers in the chapter <info:number>.
 
 ## BigInt [#bigint-type]
 
-In JavaScript, the "number" type cannot safely represent integer values larger than <code>(2<sup>53</sup>-1)</code> (that’s `9007199254740991`), or less than <code>-(2<sup>53</sup>-1)</code> for negatives. Technically "number" type can store larger integers (up to <code>1.7976931348623157 * 10<sup>308</sup></code>), but outside of the safe integer range <code>±(2<sup>53</sup>-1)</code> a lot of integer values can't be represented using this data type: some of them are "missed" due to the limitation caused by their internal binary representation. For example, all the odd integers greater than <code>(2<sup>53</sup>-1)</code> are "missed" in the "number" type.
+In JavaScript, the "number" type cannot safely represent integer values larger than <code>(2<sup>53</sup>-1)</code> (that's `9007199254740991`), or less than <code>-(2<sup>53</sup>-1)</code> for negatives. Technically "number" type can store larger integers (up to <code>1.7976931348623157 * 10<sup>308</sup></code>), but outside of the safe integer range <code>±(2<sup>53</sup>-1)</code> a lot of integer values can't be represented using this data type: some of them are "missed" due to the limitation caused by their internal binary representation. For example, all the odd integers greater than <code>(2<sup>53</sup>-1)</code> are "missed" in the "number" type.
 
 For most purposes <code>±(2<sup>53</sup>-1)</code> range is quite enough, but sometimes we need the entire range of really big integers without missing any of them, e.g. for cryptography or microsecond-precision timestamps.
 

--- a/1-js/02-first-steps/05-types/article.md
+++ b/1-js/02-first-steps/05-types/article.md
@@ -68,9 +68,9 @@ We'll see more about working with numbers in the chapter <info:number>.
 
 ## BigInt [#bigint-type]
 
-In JavaScript, the "number" type cannot represent integer values larger than <code>(2<sup>53</sup>-1)</code> (that's `9007199254740991`), or less than <code>-(2<sup>53</sup>-1)</code> for negatives. It's a technical limitation caused by their internal representation.
+In JavaScript, the "number" type cannot safely represent integer values larger than <code>(2<sup>53</sup>-1)</code> (that’s `9007199254740991`), or less than <code>-(2<sup>53</sup>-1)</code> for negatives. Technically "number" type can store larger integers (up to <code>1.7976931348623157 * 10<sup>308</sup></code>), but outside of the safe integer range <code>±(2<sup>53</sup>-1)</code> a lot of integer values can't be represented using this data type: some of them are "missed" due to the limitation caused by their internal binary representation. For example, all the odd integers greater than <code>(2<sup>53</sup>-1)</code> are "missed" in the "number" type.
 
-For most purposes that's quite enough, but sometimes we need really big numbers, e.g. for cryptography or microsecond-precision timestamps.
+For most purposes <code>±(2<sup>53</sup>-1)</code> range is quite enough, but sometimes we need the entire range of really big integers without missing any of them, e.g. for cryptography or microsecond-precision timestamps.
 
 `BigInt` type was recently added to the language to represent integers of arbitrary length.
 

--- a/1-js/05-data-types/02-number/article.md
+++ b/1-js/05-data-types/02-number/article.md
@@ -2,9 +2,9 @@
 
 In modern JavaScript, there are two types of numbers:
 
-1. Regular numbers in JavaScript are stored in 64-bit format [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754-2008_revision), also known as "double precision floating point numbers". These are numbers that we're using most of the time, and we'll talk about them in this chapter.
+1. Regular numbers in JavaScript are stored in 64-bit format [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754), also known as "double precision floating point numbers". These are numbers that we're using most of the time, and we'll talk about them in this chapter.
 
-2. BigInt numbers represent integers of arbitrary length. They are sometimes needed because a regular number can't safely exceed <code>2<sup>53</sup></code> or be less than <code>-2<sup>53</sup></code>. As bigints are used in few special areas, we devote them a special chapter <info:bigint>.
+2. BigInt numbers represent integers of arbitrary length. They are sometimes needed because a regular integer number can't safely exceed <code>(2<sup>53</sup>-1)</code> or be less than <code>-(2<sup>53</sup>-1)</code>, as we mentioned earlier in the chapter <info:types>. As bigints are used in few special areas, we devote them a special chapter <info:bigint>.
 
 So here we'll talk about regular numbers. Let's expand our knowledge of them.
 
@@ -192,7 +192,7 @@ There are two ways to do so:
 
 ## Imprecise calculations
 
-Internally, a number is represented in 64-bit format [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754-2008_revision), so there are exactly 64 bits to store a number: 52 of them are used to store the digits, 11 of them store the position of the decimal point (they are zero for integer numbers), and 1 bit is for the sign.
+Internally, a number is represented in 64-bit format [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754-2008_revision), so there are exactly 64 bits to store a number: 52 of them are used to store the digits, 11 of them store the position of the decimal point, and 1 bit is for the sign.
 
 If a number is really huge, it may overflow the 64-bit storage and become a special numeric value `Infinity`:
 

--- a/1-js/05-data-types/02-number/article.md
+++ b/1-js/05-data-types/02-number/article.md
@@ -192,7 +192,7 @@ There are two ways to do so:
 
 ## Imprecise calculations
 
-Internally, a number is represented in 64-bit format [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754-2008_revision), so there are exactly 64 bits to store a number: 52 of them are used to store the digits, 11 of them store the position of the decimal point, and 1 bit is for the sign.
+Internally, a number is represented in 64-bit format [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754), so there are exactly 64 bits to store a number: 52 of them are used to store the digits, 11 of them store the position of the decimal point, and 1 bit is for the sign.
 
 If a number is really huge, it may overflow the 64-bit storage and become a special numeric value `Infinity`:
 


### PR DESCRIPTION
Some comments about existing text and proposed changes.

In "Data types" chapter:

`In JavaScript, the “number” type cannot represent integer values larger than (2^53-1) (that’s 9007199254740991), or less than -(2^53-1) for negatives.`

Number type can represent a lot of integers outside of the range ±(2^53 - 1), up to Number.MAX_VALUE, but some of the integers outside of the safe range will be missed. For example, Number type can perfectly store such integers as 2^53 + 2 and 2^53 + 4, but can't store 2^53 + 1 and 2^53 + 3.
So we need to say "cannot safely represent" instead of "cannot represent".

In "Numbers" chapter:

`BigInt numbers represent integers of arbitrary length. They are sometimes needed because a regular number can’t safely exceed 2^53 or be less than -2^53`

According to the specification (https://tc39.es/ecma262/#sec-number.issafeinteger) the safe range for integers of the Number type is limited by ±(2^53 - 1). 2^53 can be represented using the Number type but it's an unsafe value already because 2^53 === 2^53 + 1 is true for the Number type.
So if we talk about safe representation, we should use ±(2^53 - 1) range, but not ±2^53.

`Internally, a number is represented in 64-bit format IEEE-754, so there are exactly 64 bits to store a number: 52 of them are used to store the digits, 11 of them store the position of the decimal point (they are zero for integer numbers), and 1 bit is for the sign.`

We need to remove phrase "they are zero for integer numbers" here.
According to the IEEE-754 standard, the exponent (the position of the decimal point) in double-precision 64-bit binary format is stored using offset binary representation (so called biased exponent). That's why the zero exponent value will be represented as 01111111111 (0 + offset 1023), but not 00000000000.
All the 11 bits for the exponent will be zero only for two values of Number type: +0 and -0.