### PR TITLE
👾 fix typo

### DIFF
--- a/1-js/05-data-types/06-iterable/article.md
+++ b/1-js/05-data-types/06-iterable/article.md
@@ -28,7 +28,7 @@ let range = {
 
 To make the `range` object iterable (and thus let `for..of` work) we need to add a method to the object named `Symbol.iterator` (a special built-in symbol just for that).
 
-1. When `for..of` starts, it calls that method once (or errors if not found). The method must return an *iterator* -- an object with the method `next`.
+1. When `for..of` starts, it calls that method once (or error if not found). The method must return an *iterator* -- an object with the method `next`.
 2. Onward, `for..of` works *only with that returned object*.
 3. When `for..of` wants the next value, it calls `next()` on that object.
 4. The result of `next()` must have the form `{done: Boolean, value: any}`, where `done=true` means that the loop is finished, otherwise `value` is the next value.


### PR DESCRIPTION
I believe that the word `error ` should be in the singular

![image](https://user-images.githubusercontent.com/73550760/178150596-d9d8575e-c65e-4cd7-ae54-10d7bbfb2238.png)
