### PR TITLE
Fix typo in pointercancel section

### DIFF
--- a/2-ui/3-event-details/6-pointer-events/article.md
+++ b/2-ui/3-event-details/6-pointer-events/article.md
@@ -111,7 +111,7 @@ Such causes are:
 
 We'll demonstrate `pointercancel` on a practical example to see how it affects us.
 
-Let's say we're impelementing drag'n'drop for a ball, just as in the beginning of the article <info:mouse-drag-and-drop>.
+Let's say we're implementing drag'n'drop for a ball, just as in the beginning of the article <info:mouse-drag-and-drop>.
 
 Here is the flow of user actions and the corresponding events:
 


### PR DESCRIPTION
Noticed that the word implementing was spelt incorrectly within the section for pointercancel events, thus I decided to correct it for reading comprehension reasons.