### PR TITLE
Adding clarification for undefined arguments

### DIFF
--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -206,7 +206,7 @@ function showMessage(from, *!*text = "no text given"*/!*) {
 showMessage("Ann"); // Ann: no text given
 ```
 
-Now if the `text` parameter is not passed, it will get the value `"no text given"`
+Now if the `text` parameter is not passed, or if the argument passed evaluates to `undefined`, it will get the value `"no text given"`
 
 Here `"no text given"` is a string, but it can be a more complex expression, which is only evaluated and assigned if the parameter is missing. So, this is also possible:
 


### PR DESCRIPTION
Consider the following code:

```javascript
let someFunction = (someString = "nothing passed") => console.log(someString);

someFunction("hello") // hello
someFunction() // nothing passed
someFunction(undefined) // nothing passed
someFunction(null) // null
someFunction(0) // 0
someFunction((() => {return undefined})()) // nothing passed

/* We learned here that default values are assigned to anything undefined,
   not just parameters that do not receive a value.  If you pass in undefined, you're going to get
   a default assignment as per the parameter definition
*/
```

I'd like to clarify for future readers that even any argument getting passed in that evaluates as `undefined` we'll receive the default value - not *just* parameters/arguments that are not passed.  If you want `undefined` to pass through to your function, you need to take this into account when designing your function signature.