### PR TITLE
Update article.md

### DIFF
--- a/1-js/05-data-types/08-weakmap-weakset/article.md
+++ b/1-js/05-data-types/08-weakmap-weakset/article.md
@@ -218,7 +218,7 @@ let cache = new WeakMap();
 // calculate and remember the result
 function process(obj) {
   if (!cache.has(obj)) {
-    let result = /* calculate the result for */ obj;
+    let result = /* calculate the result for, eg:obj.toString() */ obj.toString();
 
     cache.set(obj, result);
   }


### PR DESCRIPTION
for the example about `cache.js` using `WeakMap`, the statement `let result = /* calculate the result for  */ obj;` is the same as `let result = obj` , if so , the weakmap would use `obj` as key and **value** at the same time , if you set `obj` to `null` later, the weakmap won't remove the key 'obj'. just want to make the example more clear.