### PR TITLE
fix: typo arr -> fruits

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -262,8 +262,8 @@ The method [arr.lastIndexOf](mdn:js/Array/lastIndexOf) is the same as `indexOf`,
 ```js run
 let fruits = ['Apple', 'Orange', 'Apple']
 
-alert( arr.indexOf('Apple') ); // 0 (first Apple)
-alert( arr.lastIndexOf('Apple') ); // 2 (last Apple)
+alert( fruits.indexOf('Apple') ); // 0 (first Apple)
+alert( fruits.lastIndexOf('Apple') ); // 2 (last Apple)
 ```
 
 ````smart header="The `includes` method handles `NaN` correctly"


### PR DESCRIPTION
```
- alert( arr.indexOf('Apple') ); // 0 (first Apple)
- alert( arr.lastIndexOf('Apple') ); // 2 (last Apple)
+ alert( fruits.indexOf('Apple') ); // 0 (first Apple)
+ alert( fruits.lastIndexOf('Apple') ); // 2 (last Apple)
```