### PR TITLE
Reword sentence on line 268

### DIFF
--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -265,7 +265,7 @@ function showMessage(from, text) {
 
 ### Alternative default parameters
 
-Sometimes it makes sense to assign default values for parameters not in the function declaration, but at a later stage.
+Sometimes it makes sense to assign default values for parameters at a later stage after the function declaration.
 
 We can check if the parameter is passed during the function execution, by comparing it with `undefined`:
 


### PR DESCRIPTION
The meaning of this sentence is ambiguous. 

This would be another solution that involves adding a missing comma.
"Sometimes it makes sense to assign default values for parameters, not in the function declaration, but at a later stage."