### PR TITLE
Update article.md

### DIFF
--- a/1-js/04-object-basics/02-object-copy/article.md
+++ b/1-js/04-object-basics/02-object-copy/article.md
@@ -136,7 +136,7 @@ We can also use the method [Object.assign](https://developer.mozilla.org/en-US/d
 The syntax is:
 
 ```js
-Object.assign(dest, [src1, src2, src3...])
+Object.assign(dest, src1, src2, src3...)
 ```
 
 - The first argument `dest` is a target object.


### PR DESCRIPTION
Object.assign(dest, src1, src2, src3...) is the right syntax, Object.assign(dest, [src1, src2, src3]) will not copy the properties of obj src instead it will copy the whole object as properties in sequential order with index as key {0: src1, 1: src2, 2: src3...., dest }