### PR TITLE
Correcting a typo in the prototype chain

### DIFF
--- a/1-js/09-classes/07-mixins/article.md
+++ b/1-js/09-classes/07-mixins/article.md
@@ -103,7 +103,7 @@ Here's the diagram (see the right part):
 
 That's because methods `sayHi` and `sayBye` were initially created in `sayHiMixin`. So even though they got copied, their `[[HomeObject]]` internal property references `sayHiMixin`, as shown in the picture above.
 
-As `super` looks for parent methods in `[[HomeObject]].[[Prototype]]`, that means it searches `sayHiMixin.[[Prototype]]`, not `User.[[Prototype]]`.
+As `super` looks for parent methods in `[[HomeObject]].[[Prototype]]`, that means it searches `sayHiMixin.[[Prototype]]`, not `User.prototype.[[Prototype]]`.
 
 ## EventMixin
 


### PR DESCRIPTION
when running super(), it normally looks for methods in ClassName.prototype.[[Prototype]]. Instead, the tutorial said ClassName.[[Prototype]], which is wrong.