### PR TITLE
Fix syntax error in object-copy article

### DIFF
--- a/1-js/04-object-basics/02-object-copy/article.md
+++ b/1-js/04-object-basics/02-object-copy/article.md
@@ -160,7 +160,7 @@ We can also use the method [Object.assign](https://developer.mozilla.org/en-US/d
 The syntax is:
 
 ```js
-Object.assign(dest, src1[, src2, src3...])
+Object.assign(dest, src1, src2, src3, ..., srcN)
 ```
 
 - The first argument `dest` is a target object.


### PR DESCRIPTION
The square brackets in 'Object.assign(dest, src1[, src2, src3...])' 
results in a syntax error. The correct syntax should be  
'Object.assign(dest, src1, src2, src3, ...)', but I've added a srcN, changing it 
to 'Object.assign(dest, src1, src2, src3, ..., srcN)' to make it more relevant 
to the explanation found underneath the original code snippet.