### PR TITLE
Update "Import *" section

### DIFF
--- a/1-js/13-modules/02-import-export/article.md
+++ b/1-js/13-modules/02-import-export/article.md
@@ -93,25 +93,8 @@ At first sight, "import everything" seems such a cool thing, short to write, why
 
 Well, there are few reasons.
 
-1. Modern build tools ([webpack](https://webpack.js.org/) and others) bundle modules together and optimize them to speedup loading and remove unused stuff.
-
-    Let's say, we added a 3rd-party library `say.js` to our project with many functions:
-    ```js
-    // 📁 say.js
-    export function sayHi() { ... }
-    export function sayBye() { ... }
-    export function becomeSilent() { ... }
-    ```
-
-    Now if we only use one of `say.js` functions in our project:
-    ```js
-    // 📁 main.js
-    import {sayHi} from './say.js';
-    ```
-    ...Then the optimizer will see that and remove the other functions from the bundled code, thus making the build smaller. That is called "tree-shaking".
-
-2. Explicitly listing what to import gives shorter names: `sayHi()` instead of `say.sayHi()`.
-3. Explicit list of imports gives better overview of the code structure: what is used and where. It makes code support and refactoring easier.
+1. Explicitly listing what to import gives shorter names: `sayHi()` instead of `say.sayHi()`.
+1. Explicit list of imports gives better overview of the code structure: what is used and where. It makes code support and refactoring easier.
 
 ## Import "as"
 


### PR DESCRIPTION
Despite of what you said about `import * as <obj>`, if we use `import * as <obj>` when that 3rd-party library uses ES modules, Webpack is still doing tree-shaking and I think the first reason is redundant and can be removed because when that 3rd-party library uses commonJS module system, using `import {item1, item2} from module` will load the whole module and won't be making the build smaller.

https://github.com/webpack/webpack/tree/main/examples/harmony-unused#examplejs