### PR TITLE
fix small typo in web-components slots chapter.

### DIFF
--- a/8-web-components/5-slots-composition/article.md
+++ b/8-web-components/5-slots-composition/article.md
@@ -381,7 +381,7 @@ If we'd like to track internal modifications of light DOM from JavaScript, that'
 
 Finally, let's mention the slot-related JavaScript methods.
 
-As we've seen before, JavaScript looks at the "real" DOM, without flattening. But, if the shadow tree has `{mode: 'open'}`, then we can figure out which elements assigned to a slot and, vise-versa, the slot by the element inside it:
+As we've seen before, JavaScript looks at the "real" DOM, without flattening. But, if the shadow tree has `{mode: 'open'}`, then we can figure out which elements assigned to a slot and, vice versa, the slot by the element inside it:
 
 - `node.assignedSlot` -- returns the `<slot>` element that the `node` is assigned to.
 - `slot.assignedNodes({flatten: true/false})` -- DOM nodes, assigned to the slot. The `flatten` option is `false` by default. If explicitly set to `true`, then it looks more deeply into the flattened DOM, returning nested slots in case of nested components and the fallback content if no node assigned.

--- a/8-web-components/5-slots-composition/article.md
+++ b/8-web-components/5-slots-composition/article.md
@@ -381,7 +381,7 @@ If we'd like to track internal modifications of light DOM from JavaScript, that'
 
 Finally, let's mention the slot-related JavaScript methods.
 
-As we've seen before, JavaScript looks at the "real" DOM, without flattening. But, if the shadow tree has `{mode: 'open'}`, then we can figure out which elements assigned to a slot and, vice versa, the slot by the element inside it:
+As we've seen before, JavaScript looks at the "real" DOM, without flattening. But, if the shadow tree has `{mode: 'open'}`, then we can figure out which elements assigned to a slot and, vice-versa, the slot by the element inside it:
 
 - `node.assignedSlot` -- returns the `<slot>` element that the `node` is assigned to.
 - `slot.assignedNodes({flatten: true/false})` -- DOM nodes, assigned to the slot. The `flatten` option is `false` by default. If explicitly set to `true`, then it looks more deeply into the flattened DOM, returning nested slots in case of nested components and the fallback content if no node assigned.


### PR DESCRIPTION
I don't see anyone using vice versa with "-" in between, so decided to remove it as well.