### PR TITLE
Omitting parentheses after `new`

### DIFF
--- a/1-js/04-object-basics/06-constructor-new/article.md
+++ b/1-js/04-object-basics/06-constructor-new/article.md
@@ -171,7 +171,7 @@ alert( new SmallUser().name );  // John
 Usually constructors don't have a `return` statement. Here we mention the special behavior with returning objects mainly for the sake of completeness.
 
 ````smart header="Omitting parentheses"
-By the way, we can omit parentheses after `new`, if it has no arguments:
+By the way, we can omit parentheses after `new`:
 
 ```js
 let user = new User; // <-- no parentheses


### PR DESCRIPTION
Parentheses can be omitted even if the constructor function has arguments:
```js
new function(test) {
    return { test }
}

// Works the same as
new (function(test) {
    return { test }
})();
```