### PR TITLE
Change contradicting statement

### DIFF
--- a/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
+++ b/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
@@ -218,7 +218,7 @@ And here is the picture for the nested `setTimeout`:
 
 ![](settimeout-interval.svg)
 
-**The nested `setTimeout` guarantees the fixed delay (here 100ms).**
+**The nested `setTimeout` ensures a minimum delay (100ms here) between the end of one call and the beginning of the subsequent one.**
 
 That's because a new call is planned at the end of the previous one.
 


### PR DESCRIPTION
Contradicting statements:
- The nested setTimeout guarantees the fixed delay.
- all scheduling methods do not guarantee the exact delay

Fixes #3099  