### PR TITLE
Add .at( ) to strings summary

### DIFF
--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -505,7 +505,7 @@ This method actually has two additional arguments specified in [the documentatio
 
 - There are 3 types of quotes. Backticks allow a string to span multiple lines and embed expressions `${…}`.
 - We can use special characters, such as a line break `\n`.
-- To get a character, use: `[]`.
+- To get a character, use: `[]` or `at`.
 - To get a substring, use: `slice` or `substring`.
 - To lowercase/uppercase a string, use: `toLowerCase/toUpperCase`.
 - To look for a substring, use: `indexOf`, or `includes/startsWith/endsWith` for simple checks.


### PR DESCRIPTION
1) thanks, I liked  at( ).

2) `at` alone seems odd but ` .at( ) ` doesnt fit with the neighbors `slice` `indexOf ` ...
