### PR TITLE
unreal keys

### DIFF
--- a/1-js/01-getting-started/4-devtools/article.md
+++ b/1-js/01-getting-started/4-devtools/article.md
@@ -16,7 +16,7 @@ Open the page [bug.html](bug.html).
 
 There's an error in the JavaScript code on it. It's hidden from a regular visitor's eyes, so let's open developer tools to see it.
 
-Press `key:F12` or, if you're on Mac, then `key:Cmd+Opt+J`.
+Press `key:F12` or, if you're on Mac, then `key:Cmd`+`key:Opt`+`key:J`.
 
 The developer tools will open on the Console tab by default.
 
@@ -36,7 +36,7 @@ Now we can see errors, and that's enough for a start. We'll come back to develop
 ```smart header="Multi-line input"
 Usually, when we put a line of code into the console, and then press `key:Enter`, it executes.
 
-To insert multiple lines, press `key:Shift+Enter`. This way one can enter long fragments of JavaScript code.
+To insert multiple lines, press `key:Shift`+`key:Enter`. This way one can enter long fragments of JavaScript code.
 ```
 
 ## Firefox, Edge, and others
@@ -53,11 +53,11 @@ Open Preferences and go to the "Advanced" pane. There's a checkbox at the bottom
 
 ![safari](safari.png)
 
-Now `key:Cmd+Opt+C` can toggle the console. Also, note that the new top menu item named "Develop" has appeared. It has many commands and options.
+Now `key:Cmd`+`key:Opt`+`key:C` can toggle the console. Also, note that the new top menu item named "Develop" has appeared. It has many commands and options.
 
 ## Summary
 
 - Developer tools allow us to see errors, run commands, examine variables, and much more.
-- They can be opened with `key:F12` for most browsers on Windows. Chrome for Mac needs `key:Cmd+Opt+J`, Safari: `key:Cmd+Opt+C` (need to enable first).
+- They can be opened with `key:F12` for most browsers on Windows. Chrome for Mac needs `key:Cmd`+`key:Opt`+`key:J`, Safari: `key:Cmd`+`key:Opt`+`key:C` (need to enable first).
 
 Now we have the environment ready. In the next section, we'll get down to JavaScript.

--- a/1-js/02-first-steps/02-structure/article.md
+++ b/1-js/02-first-steps/02-structure/article.md
@@ -132,7 +132,7 @@ alert('World');
 ```
 
 ```smart header="Use hotkeys!"
-In most editors, a line of code can be commented out by pressing the `key:Ctrl+/` hotkey for a single-line comment and something like `key:Ctrl+Shift+/` -- for multiline comments (select a piece of code and press the hotkey). For Mac, try `key:Cmd` instead of `key:Ctrl` and `key:Option` instead of `key:Shift`.
+In most editors, a line of code can be commented out by pressing the `key:Ctrl`+`key:/` hotkey for a single-line comment and something like `key:Ctrl`+`key:Shift`+`key:/` -- for multiline comments (select a piece of code and press the hotkey). For Mac, try `key:Cmd` instead of `key:Ctrl` and `key:Option` instead of `key:Shift`.
 ```
 
 ````warn header="Nested comments are not supported!"

--- a/1-js/02-first-steps/03-strict-mode/article.md
+++ b/1-js/02-first-steps/03-strict-mode/article.md
@@ -52,7 +52,7 @@ Sometimes, when `use strict` makes a difference, you'll get incorrect results.
 
 So, how to actually `use strict` in the console?
 
-First, you can try to press `key:Shift+Enter` to input multiple lines, and put `use strict` on top, like this:
+First, you can try to press `key:Shift`+`key:Enter` to input multiple lines, and put `use strict` on top, like this:
 
 ```js
 'use strict'; <Shift+Enter for a newline>

--- a/1-js/03-code-quality/01-debugging-chrome/article.md
+++ b/1-js/03-code-quality/01-debugging-chrome/article.md
@@ -11,7 +11,7 @@ We'll be using Chrome here, because it has enough features, most other browsers 
 Your Chrome version may look a little bit different, but it still should be obvious what's there.
 
 - Open the [example page](debugging/index.html) in Chrome.
-- Turn on developer tools with `key:F12` (Mac: `key:Cmd+Opt+I`).
+- Turn on developer tools with `key:F12` (Mac: `key:Cmd`+`key:Opt`+`key:I`).
 - Select the `Sources` panel.
 
 Here's what you should see if you are doing it for the first time:
@@ -88,7 +88,7 @@ Such command works only when the development tools are open, otherwise the brows
 
 ## Pause and look around
 
-In our example, `hello()` is called during the page load, so the easiest way to activate the debugger (after we've set the breakpoints) is to reload the page. So let's press `key:F5` (Windows, Linux) or `key:Cmd+R` (Mac).
+In our example, `hello()` is called during the page load, so the easiest way to activate the debugger (after we've set the breakpoints) is to reload the page. So let's press `key:F5` (Windows, Linux) or `key:Cmd`+`key:R` (Mac).
 
 As the breakpoint is set, the execution pauses at the 4th line:
 
@@ -147,7 +147,7 @@ There are buttons for it at the top of the right panel. Let's engage them.
 
     For the future, just note that "Step" command ignores async actions, such as `setTimeout` (scheduled function call), that execute later. The "Step into" goes into their code, waiting for them if necessary. See [DevTools manual](https://developers.google.com/web/updates/2018/01/devtools#async) for more details.
 
-<span class="devtools" style="background-position:-32px -194px"></span> -- "Step out": continue the execution till the end of the current function, hotkey `key:Shift+F11`.
+<span class="devtools" style="background-position:-32px -194px"></span> -- "Step out": continue the execution till the end of the current function, hotkey `key:Shift`+`key:F11`.
 : Continue the execution and stop it at the very last line of the current function. That's handy when we accidentally entered a nested call using <span class="devtools" style="background-position:-200px -190px"></span>, but it does not interest us, and we want to continue to its end as soon as possible.
 
 <span class="devtools" style="background-position:-61px -74px"></span> -- enable/disable all breakpoints.

--- a/2-ui/3-event-details/1-mouse-events-basics/article.md
+++ b/2-ui/3-event-details/1-mouse-events-basics/article.md
@@ -92,7 +92,7 @@ Event properties:
 
 They are `true` if the corresponding key was pressed during the event.
 
-For instance, the button below only works on `key:Alt+Shift`+click:
+For instance, the button below only works on `key:Alt`+`key:Shift`+click:
 
 ```html autorun height=60
 <button id="button">Alt+Shift+Click on me!</button>
@@ -113,7 +113,7 @@ On Windows and Linux there are modifier keys `key:Alt`, `key:Shift` and `key:Ctr
 
 In most applications, when Windows/Linux uses `key:Ctrl`, on Mac `key:Cmd` is used.
 
-That is: where a Windows user presses `key:Ctrl+Enter` or `key:Ctrl+A`, a Mac user would press `key:Cmd+Enter` or `key:Cmd+A`, and so on.
+That is: where a Windows user presses `key:Ctrl`+`key:Enter` or `key:Ctrl`+`key:A`, a Mac user would press `key:Cmd`+`key:Enter` or `key:Cmd`+`key:A`, and so on.
 
 So if we want to support combinations like `key:Ctrl`+click, then for Mac it makes sense to use `key:Cmd`+click. That's more comfortable for Mac users.
 

--- a/2-ui/3-event-details/7-keyboard-events/article.md
+++ b/2-ui/3-event-details/7-keyboard-events/article.md
@@ -37,7 +37,7 @@ The `event.key` is exactly the character, and it will be different. But `event.c
 | Key          | `event.key` | `event.code` |
 |--------------|-------------|--------------|
 | `key:Z`      |`z` (lowercase)         |`KeyZ`        |
-| `key:Shift+Z`|`Z` (uppercase)          |`KeyZ`        |
+| `key:Shift`+`key:Z`|`Z` (uppercase)          |`KeyZ`        |
 
 
 If a user works with different languages, then switching to another language would make a totally different character instead of `"Z"`. That will become the value of `event.key`, while `event.code` is always the same: `"KeyZ"`.
@@ -71,7 +71,7 @@ What if a key does not give any character? For instance, `key:Shift` or `key:F1`
 
 Please note that `event.code` specifies exactly which key is pressed. For instance, most keyboards have two `key:Shift` keys: on the left and on the right side. The `event.code` tells us exactly which one was pressed, and `event.key` is responsible for the "meaning" of the key: what it is (a "Shift").
 
-Let's say, we want to handle a hotkey: `key:Ctrl+Z` (or `key:Cmd+Z` for Mac). Most text editors hook the "Undo" action on it. We can set a listener on `keydown` and check which key is pressed.
+Let's say, we want to handle a hotkey: `key:Ctrl`+`key:Z` (or `key:Cmd`+`key:Z` for Mac). Most text editors hook the "Undo" action on it. We can set a listener on `keydown` and check which key is pressed.
 
 There's a dilemma here: in such a listener, should we check the value of `event.key` or `event.code`?
 
@@ -129,10 +129,10 @@ For instance:
 - A character appears on the screen (the most obvious outcome).
 - A character is deleted (`key:Delete` key).
 - The page is scrolled (`key:PageDown` key).
-- The browser opens the "Save Page" dialog (`key:Ctrl+S`)
+- The browser opens the "Save Page" dialog (`key:Ctrl`+`key:S`)
 -  ...and so on.
 
-Preventing the default action on `keydown` can cancel most of them, with the exception of OS-based special keys. For instance, on Windows `key:Alt+F4` closes the current browser window. And there's no way to stop it by preventing the default action in JavaScript.
+Preventing the default action on `keydown` can cancel most of them, with the exception of OS-based special keys. For instance, on Windows `key:Alt`+`key:F4` closes the current browser window. And there's no way to stop it by preventing the default action in JavaScript.
 
 For instance, the `<input>` below expects a phone number, so it does not accept keys except digits, `+`, `()` or `-`:
 

--- a/2-ui/99-ui-misc/02-selection-range/article.md
+++ b/2-ui/99-ui-misc/02-selection-range/article.md
@@ -321,7 +321,7 @@ There also exist methods to compare ranges, but these are rarely used. When you 
 
 We may create `Range` objects, pass them around -- they do not visually select anything on their own.
 
-The document selection is represented by `Selection` object, that can be obtained as `window.getSelection()` or `document.getSelection()`. A selection may include zero or more ranges. At least, the [Selection API specification](https://www.w3.org/TR/selection-api/) says so. In practice though, only Firefox allows to select multiple ranges in the document by using `key:Ctrl+click` (`key:Cmd+click` for Mac).
+The document selection is represented by `Selection` object, that can be obtained as `window.getSelection()` or `document.getSelection()`. A selection may include zero or more ranges. At least, the [Selection API specification](https://www.w3.org/TR/selection-api/) says so. In practice though, only Firefox allows to select multiple ranges in the document by using `key:Ctrl`+click (`key:Cmd`+click for Mac).
 
 Here's a screenshot of a selection with 3 ranges, made in Firefox:
 

--- a/7-animation/2-css-animations/article.md
+++ b/7-animation/2-css-animations/article.md
@@ -258,7 +258,7 @@ But how do we make a Bezier curve for a specific task? There are many tools.
 
 - For instance, we can do it on the site <https://cubic-bezier.com>.
 - Browser developer tools also have special support for Bezier curves in CSS:
-    1. Open the developer tools with `key:F12` (Mac: `key:Cmd+Opt+I`).
+    1. Open the developer tools with `key:F12` (Mac: `key:Cmd`+`key:Opt`+`key:I`).
     2. Select the `Elements` tab, then pay attention to the `Styles` sub-panel at the right side.
     3. CSS properties with a word `cubic-bezier` will have an icon before this word.
     4. Click this icon to edit the curve.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6558304/194685746-eba9278c-cd47-4eb2-aa9f-d3e363a0405c.png)

[Cmd] +[Opt] + [J]  instead of
[Cmd +Opt + J],  prettier and accurate

![image](https://user-images.githubusercontent.com/6558304/194685958-e7e58d14-4a6d-46d6-a186-cd1a3afcd9e3.png)
(individual keys, I didnt test darkmode) 
...
over 100  "key:" 
but (?=.`key:)(?=.*\+.`) only 20, changed manually.

It was fun but the pr looks silly.
drop it if you like
