### PR TITLE
Remove use of error.message in onerror()

### DIFF
--- a/5-network/11-websocket/article.md
+++ b/5-network/11-websocket/article.md
@@ -56,7 +56,7 @@ socket.onclose = function(event) {
 };
 
 socket.onerror = function(error) {
-  alert(`[error] ${error.message}`);
+  alert(`[error]`);
 };
 ```
 


### PR DESCRIPTION
The event type for `onerror()` is a vanilla `Event` that has no `message` property (or anything interesting about the error). Further info from this StackOverflow question: [Javascript doesn't catch error in WebSocket instantiation](https://stackoverflow.com/questions/31002592/javascript-doesnt-catch-error-in-websocket-instantiation/31003057#31003057).