### PR TITLE
For the completeness of example.

### DIFF
--- a/1-js/05-data-types/08-weakmap-weakset/article.md
+++ b/1-js/05-data-types/08-weakmap-weakset/article.md
@@ -182,6 +182,7 @@ function process(obj) {
     let result = /* calculations of the result for */ obj;
 
     cache.set(obj, result);
+    return result;
   }
 
   return cache.get(obj);
@@ -221,6 +222,7 @@ function process(obj) {
     let result = /* calculate the result for */ obj;
 
     cache.set(obj, result);
+    return result;
   }
 
   return cache.get(obj);


### PR DESCRIPTION
because after all,  ```let result1 = process(obj); // calculated``` would be ```undefined```. 

Also using this opportunity, wanted to say thanks to creator and editors of this great tutorial!