### PR TITLE
Bug Fix

### DIFF
--- a/7-animation/2-css-animations/1-animate-logo-css/solution.view/index.html
+++ b/7-animation/2-css-animations/1-animate-logo-css/solution.view/index.html
@@ -27,9 +27,9 @@
   <img id="flyjet" src="https://en.js.cx/clipart/flyjet.jpg">
 
   <script>
-    flyjet.onclick = function() {
+   let ended = false;
 
-      let ended = false;
+    flyjet.onclick = function() {
 
       flyjet.addEventListener('transitionend', function() {
         if (!ended) {


### PR DESCRIPTION
Article "[CSS-animations](https://javascript.info/css-animations)" / [First task](https://javascript.info/task/animate-logo-css).

The task description says: 

> During the animation process, there may be more clicks on the plane. They shouldn’t “break” anything.

If you click the picture again during the animation, the message "Done!" appears twice. Fixed in this PR.
