### PR TITLE
Correct a small mistake

### DIFF
--- a/5-network/05-fetch-crossorigin/article.md
+++ b/5-network/05-fetch-crossorigin/article.md
@@ -2,11 +2,11 @@
 
 If we send a `fetch` request to another web-site, it will probably fail.
 
-For instance, let's try fetching `http://example.com`:
+For instance, let's try fetching `https://example.com`:
 
 ```js run async
 try {
-  await fetch('http://example.com');
+  await fetch('https://example.com');
 } catch(err) {
   alert(err); // Failed to fetch
 }


### PR DESCRIPTION
Correct a small mistake: Because javascript.info is https, the actual reason for the failure of fetching the http address is "Mixed Content". As the console says, "Mixed Content: The page at 'https://zh.javascript.info/fetch-crossorigin' was loaded over HTTPS, but requested an insecure resource 'http://example.com/'. This request has been blocked; the content must be served over HTTPS."
Change http to https to reflect the impact of cross-origin requests.