### PR TITLE
Suggestion

### DIFF
--- a/1-js/02-first-steps/07-type-conversions/article.md
+++ b/1-js/02-first-steps/07-type-conversions/article.md
@@ -34,7 +34,7 @@ String conversion is mostly obvious. A `false` becomes `"false"`, `null` becomes
 
 ## Numeric Conversion
 
-Numeric conversion in mathematical functions and expressions happen automatically.
+Numeric conversion in mathematical functions and expressions happens automatically.
 
 For example, when division `/` is applied to non-numbers:
 

--- a/1-js/02-first-steps/07-type-conversions/article.md
+++ b/1-js/02-first-steps/07-type-conversions/article.md
@@ -34,7 +34,7 @@ String conversion is mostly obvious. A `false` becomes `"false"`, `null` becomes
 
 ## Numeric Conversion
 
-Numeric conversion happens in mathematical functions and expressions automatically.
+Numeric conversion in mathematical functions and expressions happen automatically.
 
 For example, when division `/` is applied to non-numbers:
 


### PR DESCRIPTION
Will this make the idea more clear or the text more readable?

Replacing:
`Numeric conversion happens in mathematical functions and expressions automatically.`
With:
`Numeric conversion in mathematical functions and expressions happen automatically.`
