### PR TITLE
fix: condition in whilt-for chapter

### DIFF
--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -231,7 +231,7 @@ while (true) {
   let value = +prompt("Enter a number", '');
 
 *!*
-  if (!value) break; // (*)
+  if (value !== 0 && !value) break; // (*)
 */!*
 
   sum += value;


### PR DESCRIPTION
["breaking" when no number is entered] is described in line 224, but it will breaking too when enter number 0. So add "value !== 0" in condation.

Related issue https://github.com/javascript-tutorial/zh.javascript.info/issues/1109