### PR TITLE
Bezier curves: update paused demo on point move

### DIFF
--- a/7-animation/1-bezier-curve/demo.svg
+++ b/7-animation/1-bezier-curve/demo.svg
@@ -153,6 +153,9 @@ http://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html#path_C
 	      points[i].y = y;
 	      setPointCoords(point, i);
 	      drawPath();
+	      if (t > 0) {
+	        drawT(points, t - STEP);
+	      }
 	    }
 	    document.onmouseup = function() {
 	      document.onmousemove = document.onmouseup = null;
@@ -212,6 +215,7 @@ http://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html#path_C
 	  }
 	}
 
+	const STEP = 0.005;
 	let t = 0;
 	let timer;
 
@@ -241,7 +245,7 @@ http://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html#path_C
 	      return;
 	    }
 
-	    t += 0.005;
+	    t += STEP;
 	  }, 30);
 	}
 


### PR DESCRIPTION
Currently the demo of De Casteljau's algorithm only partially updates when moving a point as long as it is paused. This PR adds re-rendering for the entirety of the current frame when moving a point in a paused state (instead of only updating the point, the control segments and the final curve).

Current behavior:
![Current behavior](https://user-images.githubusercontent.com/1364809/204764918-c4ef4f6e-c7e0-4a59-ac54-802c8cc43de7.gif)

Suggested behavior:
![Suggested behavior](https://user-images.githubusercontent.com/1364809/204764956-8e0e8298-a811-47a6-bf7c-efc6cf75099c.gif)

This is just a tiny change to an article's demo animation so I assumed this implementation would be fine. Let me know if there are any issues, such as with these (or other improvements you'd like for the component):

- Performance: Update happens on every mouse move when moving a point, as is currently done for the point, the control segments and the final curve. Should be fine for this case.

- The point move handler now uses variables that are declared later before the definition of `drawT`. Wasn't sure what should be moved and where so I left the handler near its related point functions and the variables near their most related function.

- `t - step` might not be exactly the same as `t` that was used to draw the frame due to floating point errors, but this shouldn't matter.