### PR TITLE
grammar & legibility (to check)

### DIFF
--- a/5-network/10-long-polling/article.md
+++ b/5-network/10-long-polling/article.md
@@ -29,7 +29,7 @@ The flow:
 3. When a message appears - the server responds to the request with it.
 4. The browser makes a new request immediately.
 
-The situation when the browser sent a request and has a pending connection with the server, is standard for this method. Only when a message is delivered, the connection is reestablished.
+This situation, where the browser has sent a request and keeps a pending connection with the server, is standard for this method. Only when a message is delivered, the connection is closed and reestablished.
 
 ![](long-polling.svg)
 


### PR DESCRIPTION
non-native warning
The problem: I fixed it the spanish way, maybe wrong.


> The situation when the browser sent a request and has a pending connection with the server, is standard for this method.

I think the comma before "is" should be removed. 
Workaround: 2 commas.
