### PR TITLE
Update commens in few code snippets

### DIFF
--- a/1-js/07-object-properties/01-property-descriptors/article.md
+++ b/1-js/07-object-properties/01-property-descriptors/article.md
@@ -141,7 +141,7 @@ Object.defineProperty(user, "name", {
 });
 
 alert(user.name); // John
-user.name = "Pete"; // Error
+user.name = "Pete"; // Error (in strict mode, otherwise ignored)
 ```
 
 ## Non-enumerable
@@ -244,7 +244,7 @@ Object.defineProperty(user, "name", {
 });
 
 user.name = "Pete"; // works fine
-delete user.name; // Error
+delete user.name; // Error (in strict mode, otherwise ignored)
 ```
 
 And here we make `user.name` a "forever sealed" constant, just like the built-in `Math.PI`:


### PR DESCRIPTION
In the Non-writable and Non-configurable section, the comments in a few of the code snippets says 'Error' but that is only the case when the 'strict' mode is enabled. I understand that it is also mentioned but it should be reflected in the code snippet as well so that the reader is absolutely clear about the concept.