### PR TITLE
Confusing info

### DIFF
--- a/1-js/02-first-steps/15-function-basics/4-pow/task.md
+++ b/1-js/02-first-steps/15-function-basics/4-pow/task.md
@@ -4,7 +4,7 @@ importance: 4
 
 # Function pow(x,n)
 
-Write a function `pow(x,n)` that returns `x` in power `n`. Or, in other words, multiplies `x` by itself `n` times and returns the result.
+Write a function `pow(x,n)` that returns `x` in power `n`.
 
 ```js
 pow(3, 2) = 3 * 3 = 9


### PR DESCRIPTION
> Or, in other words, **multiplies `x` by itself `n` times** and returns the result.

E.g. 
x = 2, n = 3

In that case, it appears that **2** must be multiplied by itself **3** times (`2 * 2 * 2 * 2`). The result would be `16`, although 2<sup>3</sup> would be `8`.
Such an expression in the task condition may confuse the readers, so I suggest it be removed.