### PR TITLE
Update button to fix horizontal scroll on mobile

### DIFF
--- a/2-ui/1-document/11-coordinates/article.md
+++ b/2-ui/1-document/11-coordinates/article.md
@@ -36,7 +36,7 @@ Additionally, there are derived properties:
 ```online
 For instance click this button to see its window coordinates:
 
-<p><input id="brTest" type="button" value="Get coordinates using button.getBoundingClientRect() for this button" onclick='showRect(this)'/></p>
+<p><input id="brTest" type="button" style="max-width: 90vw;" value="Get coordinates using button.getBoundingClientRect() for this button" onclick='showRect(this)'/></p>
 
 <script>
 function showRect(elem) {


### PR DESCRIPTION
Since the button is causing mobile screen users to have a horizontal scroll, I've fixed it giving it a max-height.

This removes the horizontal scroll that the button was causing on the entire page for mobile readers.