### PR TITLE
fix: remove the return `await`

### DIFF
--- a/1-js/11-async/08-async-await/article.md
+++ b/1-js/11-async/08-async-await/article.md
@@ -185,7 +185,7 @@ class Waiter {
 *!*
   async wait() {
 */!*
-    return await Promise.resolve(1);
+    return Promise.resolve(1);
   }
 }
 


### PR DESCRIPTION
# async function no need to use await as the returned value


## test cases

```js

class Waiter {
  async wait() {
    return await Promise.resolve(1);
  }
}

new Waiter().wait().then(console.log);
// 1

class NewWaiter {
  async wait() {
    // no need `await` ✅
    return Promise.resolve(1);
  }
}

new NewWaiter().wait().then(console.log);
// 1

```

![image](https://user-images.githubusercontent.com/7291672/215348519-077a17e6-962f-4ab6-bc00-de7fd12b8d62.png)


## refs

https://javascript.info/async-await
      