### PR TITLE
 Date and time

### DIFF
--- a/1-js/05-data-types/11-date/2-get-week-day/solution.md
+++ b/1-js/05-data-types/11-date/2-get-week-day/solution.md
@@ -10,5 +10,5 @@ function getWeekDay(date) {
 }
 
 let date = new Date(2014, 0, 3); // 3 Jan 2014
-alert( getWeekDay(date) ); // FR
+alert( getWeekDay(date) );       // FR
 ```

--- a/1-js/05-data-types/11-date/3-weekday/_js.view/solution.js
+++ b/1-js/05-data-types/11-date/3-weekday/_js.view/solution.js
@@ -2,7 +2,7 @@ function getLocalDay(date) {
 
   let day = date.getDay();
 
-  if (day == 0) { // weekday 0 (sunday) is 7 in european
+  if (day == 0) { // weekday 0 (Sunday) is 7 in Europe
     day = 7;
   }
 

--- a/1-js/05-data-types/11-date/3-weekday/task.md
+++ b/1-js/05-data-types/11-date/3-weekday/task.md
@@ -8,5 +8,5 @@ European countries have days of week starting with Monday (number 1), then Tuesd
 
 ```js no-beautify
 let date = new Date(2012, 0, 3);  // 3 Jan 2012
-alert( getLocalDay(date) );       // tuesday, should show 2
+alert( getLocalDay(date) );       // Tuesday, should show 2
 ```

--- a/1-js/05-data-types/11-date/7-get-seconds-to-tomorrow/solution.md
+++ b/1-js/05-data-types/11-date/7-get-seconds-to-tomorrow/solution.md
@@ -1,4 +1,4 @@
-To get the number of milliseconds till tomorrow, we can substract the current date from "tomorrow 00:00:00".
+To get the number of milliseconds till tomorrow, we can subtract the current date from "tomorrow 00:00:00".
 
 First, we generate that "tomorrow", and then do it:
 

--- a/1-js/05-data-types/11-date/7-get-seconds-to-tomorrow/solution.md
+++ b/1-js/05-data-types/11-date/7-get-seconds-to-tomorrow/solution.md
@@ -1,4 +1,4 @@
-To get the number of milliseconds till tomorrow, we can from "tomorrow 00:00:00" substract the current date.
+To get the number of milliseconds till tomorrow, we can substract the current date from "tomorrow 00:00:00".
 
 First, we generate that "tomorrow", and then do it:
 

--- a/1-js/05-data-types/11-date/8-format-date-relative/task.md
+++ b/1-js/05-data-types/11-date/8-format-date-relative/task.md
@@ -6,7 +6,7 @@ importance: 4
 
 Write a function `formatDate(date)` that should format `date` as follows:
 
-- If since `date` passed less than 1 second, then `"right now"`.
+- If less than 1 second passed since `date`, then `"right now"`.
 - Otherwise, if since `date` passed less than 1 minute, then `"n sec. ago"`.
 - Otherwise, if less than an hour, then `"m min. ago"`.
 - Otherwise, the full date in the format `"DD.MM.YY HH:mm"`. That is: `"day.month.year hours:minutes"`, all in 2-digit format, e.g. `31.12.16 10:00`.

--- a/1-js/05-data-types/11-date/8-format-date-relative/task.md
+++ b/1-js/05-data-types/11-date/8-format-date-relative/task.md
@@ -8,7 +8,7 @@ Write a function `formatDate(date)` that should format `date` as follows:
 
 - If less than 1 second passed since `date`, then `"right now"`.
 - Otherwise, if less than 1 minute passed since `date`, then `"n sec. ago"`.
-- Otherwise, if less than an hour, then `"m min. ago"`.
+- Otherwise, if less than an hour passed, then `"m min. ago"`.
 - Otherwise, the full date in the format `"DD.MM.YY HH:mm"`. That is: `"day.month.year hours:minutes"`, all in 2-digit format, e.g. `31.12.16 10:00`.
 
 For instance:

--- a/1-js/05-data-types/11-date/8-format-date-relative/task.md
+++ b/1-js/05-data-types/11-date/8-format-date-relative/task.md
@@ -7,7 +7,7 @@ importance: 4
 Write a function `formatDate(date)` that should format `date` as follows:
 
 - If less than 1 second passed since `date`, then `"right now"`.
-- Otherwise, if since `date` passed less than 1 minute, then `"n sec. ago"`.
+- Otherwise, if less than 1 minute passed since `date`, then `"n sec. ago"`.
 - Otherwise, if less than an hour, then `"m min. ago"`.
 - Otherwise, the full date in the format `"DD.MM.YY HH:mm"`. That is: `"day.month.year hours:minutes"`, all in 2-digit format, e.g. `31.12.16 10:00`.
 

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -413,7 +413,7 @@ alert(date);
 ## Summary
 
 - Date and time are represented with the [Date](mdn:js/Date) object. We can't create "only date" or "only time": `Date` objects always carry both.
-- Months are counted from zero (yes, January is a zero month).
+- Months are counted from zero (yes, January is month zero).
 - Days of week in `getDay()` are also counted from zero (that's Sunday).
 - `Date` auto-corrects itself when out-of-range components are set. Good for adding/subtracting days/months/hours.
 - Dates can be subtracted, giving their difference in milliseconds. That's because a `Date` becomes the timestamp when converted to a number.

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -54,7 +54,7 @@ To create a new `Date` object call `new Date()` with one of the following argume
     // Wed Jan 25 2017 16:00:00 GMT-0800 (Pacific Standard Time)
     ```
 
-`new Date(year, month, date, hours, minutes, seconds, ms)`
+`new Date(year, month, day, hours, minutes, seconds, ms)`
 : Create the date with the given components in the local time zone. Only the first two arguments are obligatory.
 
     - The `year` should have 4 digits. For compatibility, 2 digits are also accepted and considered `19xx`, e.g. `98` is the same as `1998` here, but always using 4 digits is strongly encouraged.

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -412,7 +412,7 @@ alert(date);
 
 ## Summary
 
-- Date and time in JavaScript are represented with the [Date](mdn:js/Date) object. We can't create "only date" or "only time": `Date` objects always carry both.
+- Date and time are represented with the [Date](mdn:js/Date) object. We can't create "only date" or "only time": `Date` objects always carry both.
 - Months are counted from zero (yes, January is a zero month).
 - Days of week in `getDay()` are also counted from zero (that's Sunday).
 - `Date` auto-corrects itself when out-of-range components are set. Good for adding/subtracting days/months/hours.

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -399,7 +399,7 @@ For instance:
 ```js run
 let ms = Date.parse('2012-01-26T13:51:50.417-07:00');
 
-alert(ms); // 1327611110417  (timestamp)
+alert(ms); // 1327611110417 (timestamp)
 ```
 
 We can instantly create a `new Date` object from the timestamp:

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -421,7 +421,7 @@ alert(date);
 
 Note that unlike many other systems, timestamps in JavaScript are in milliseconds, not in seconds.
 
-Sometimes we need more precise time measurements. JavaScript itself does not have a way to measure time in microseconds (1 millionth of a second), but most environments provide it. For instance, browser has [performance.now()](mdn:api/Performance/now) that gives the number of milliseconds from the start of page loading with microsecond precision (3 digits after the point):
+Sometimes we need more precise time measurements. JavaScript itself does not have a way to measure time in microseconds (1 millionth of a second), but most environments provide it. For instance, browser has [performance.now()](mdn:api/Performance/now) that returns the number of milliseconds from the start of page loading with microsecond precision (3 digits after the point):
 
 ```js run
 alert(`Loading started ${performance.now()}ms ago`);

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -58,7 +58,7 @@ To create a new `Date` object call `new Date()` with one of the following argume
 : Create the date with the given components in the local time zone. Only the first two arguments are obligatory.
 
     - The `year` should have 4 digits. For compatibility, 2 digits are also accepted and considered `19xx`, e.g. `98` is the same as `1998` here, but always using 4 digits is strongly encouraged.
-    - The `month` count starts with `0` (Jan), up to `11` (Dec).
+    - The `month` count starts from `0` (Jan), up to `11` (Dec).
     - The `date` parameter is actually the day of month, if absent then `1` is assumed.
     - If `hours/minutes/seconds/ms` is absent, they are assumed to be equal `0`.
 

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -59,7 +59,7 @@ To create a new `Date` object call `new Date()` with one of the following argume
 
     - The `year` should have 4 digits. For compatibility, 2 digits are also accepted and considered `19xx`, e.g. `98` is the same as `1998` here, but always using 4 digits is strongly encouraged.
     - The `month` count starts from `0` (Jan), up to `11` (Dec).
-    - The `date` parameter is actually the day of month, if absent then `1` is assumed.
+    - The `day` parameter represents the day of the month, if absent then `1` is assumed.
     - If `hours/minutes/seconds/ms` is absent, they are assumed to be equal `0`.
 
     For instance:

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -164,7 +164,7 @@ alert(today); // still today, now 00:00:00 sharp.
 
 ## Autocorrection
 
-The *autocorrection* is a very handy feature of `Date` objects. We can set out-of-range values, and it will auto-adjust itself.
+The *autocorrection* is a very handy feature of `Date` objects. We can set an out-of-range value, and it will auto-adjust itself.
 
 For instance:
 

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -374,7 +374,7 @@ for (let i = 0; i < 10; i++) {
 ```
 
 ```warn header="Be careful doing microbenchmarking"
-Modern JavaScript engines perform many optimizations. They may tweak results of "artificial tests" compared to "normal usage", especially when we benchmark something very small, such as how an operator works, or a built-in function. So if you seriously want to understand performance, then please study how the JavaScript engine works. And then you probably won't need microbenchmarks at all.
+Modern JavaScript engines perform many optimizations. They may tweak results of "artificial tests" compared to "normal usage", especially when we benchmark something very small, such as how an operator or a built-in function works. So if you seriously want to understand performance, then please study how the JavaScript engine works. And then you probably won't need microbenchmarks at all.
 
 The great pack of articles about V8 can be found at <https://mrale.ph>.
 ```

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -31,7 +31,7 @@ To create a new `Date` object call `new Date()` with one of the following argume
 
     An integer number representing the number of milliseconds that has passed since the beginning of 1970 is called a *timestamp*.
 
-    It's a lightweight numeric representation of a date. We can always create a date from a timestamp using `new Date(timestamp)` and convert the existing `Date` object to a timestamp using the `date.getTime()` method (see below).
+    It's a lightweight numeric representation of a date. We can always create a date from a timestamp using `new Date(timestamp)` and convert the existing `Date` object to a timestamp using the `.getTime()` method (see below).
 
     Dates before 01.01.1970 have negative timestamps, e.g.:
     ```js run

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -387,7 +387,7 @@ The string format should be: `YYYY-MM-DDTHH:mm:ss.sssZ`, where:
 
 - `YYYY-MM-DD` -- is the date: year-month-day.
 - The character `"T"` is used as the delimiter.
-- `HH:mm:ss.sss` -- is the time: hours, minutes, seconds and milliseconds.
+- `HH:mm:ss.sss` -- is the time: hours:minutes:seconds.milliseconds.
 - The optional `'Z'` part denotes the time zone in the format `+-hh:mm`. A single letter `Z` would mean UTC+0.
 
 Shorter variants are also possible, like `YYYY-MM-DD` or `YYYY-MM` or even `YYYY`.

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -66,7 +66,7 @@ To create a new `Date` object call `new Date()` with one of the following argume
 
     ```js
     new Date(2011, 0, 1, 0, 0, 0, 0); // 1 Jan 2011, 00:00:00
-    new Date(2011, 0, 1); // the same, hours etc are 0 by default
+    new Date(2011, 0, 1); // the same, hours etc. are 0 by default
     ```
 
     The maximal precision is 1 ms (1/1000 sec):

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -241,7 +241,7 @@ There's a special method `Date.now()` that returns the current timestamp.
 
 It is semantically equivalent to `new Date().getTime()`, but it doesn't create an intermediate `Date` object. So it's faster and doesn't put pressure on garbage collection.
 
-It is used mostly for convenience or when performance matters, like in games in JavaScript or other specialized applications.
+It is used mostly for convenience or when performance matters, like in games or other specialized applications.
 
 So this is probably better:
 

--- a/1-js/05-data-types/11-date/article.md
+++ b/1-js/05-data-types/11-date/article.md
@@ -105,7 +105,7 @@ Additionally, we can get a day of week:
 
 There are also their UTC-counterparts, that return day, month, year and so on for the time zone UTC+0: [getUTCFullYear()](mdn:js/Date/getUTCFullYear), [getUTCMonth()](mdn:js/Date/getUTCMonth), [getUTCDay()](mdn:js/Date/getUTCDay). Just insert the `"UTC"` right after `"get"`.
 
-If your local time zone is shifted relative to UTC, then the code below shows different hours:
+If your local time zone is offset relative to UTC, then the code below shows different hours:
 
 ```js run
 // current date


### PR DESCRIPTION
Line 34 - There is no variable named date prior to this mention. We could keep `.getTime( )` as is, or use the variable `now` or `Jan01_1970`.
line 57 - Though `date` is used in some docs, `day` makes more sense and I also saw day in [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date). P.S this is just modified in one place: if agreed, will have to change this in multiple places.
line 61 - grammar fix
line 62 - replaced `is actually the day of` with `represents the day of`. I swapped date with day ahead of time, we can ignore that if line 57 does not change.
line 69 - typo
line 108 - replaced `shifted` with `offset`
line 167 - grammar fix
line 244 - took out `in JavaScript` because it is implicit and may improve readability.
line 377 - suggestion
line 390 - modified by the same logic(format) of line 388
line 402 - extra space
line 415 - took out `in JavaScript` because it is implicit and may improve readability.
line 416 - suggestion
line 424 - `returns` may be more accurate
Tasks 2 and 3 - formatting improvements
Tasks 7 and 8 - some improvements