### PR TITLE
fix: typos

### DIFF
--- a/1-js/04-object-basics/09-object-toprimitive/article.md
+++ b/1-js/04-object-basics/09-object-toprimitive/article.md
@@ -3,7 +3,7 @@
 
 What happens when objects are added `obj1 + obj2`, subtracted `obj1 - obj2` or printed using `alert(obj)`?
 
-JavaScript doesn't allow you to customize how operators work on objects. Unlike some other programming languages, such as Ruby or C++, we can't implement a special object method to handle addition (or other operators).
+JavaScript doesn't allow you to customize how operators work on objects. Unlike some other programming languages, such as Ruby or C++, we can't implement a special object method to handle addition (or other operations).
 
 In case of such operations, objects are auto-converted to primitives, and then the operation is carried out over these primitives and results in a primitive value.
 

--- a/2-ui/3-event-details/7-keyboard-events/article.md
+++ b/2-ui/3-event-details/7-keyboard-events/article.md
@@ -24,7 +24,7 @@ Try different key combinations in the text field.
 
 ## Keydown and keyup
 
-The `keydown` events happens when a key is pressed down, and then `keyup` -- when it's released.
+The `keydown` event happens when a key is pressed down, and then `keyup` -- when it's released.
 
 ### event.code and event.key
 


### PR DESCRIPTION
events -> event since referring to a single event
operators -> operations(addition)