### PR TITLE
fix: add note about html attribute usage - Events focus/blur

### DIFF
--- a/2-ui/4-forms-controls/2-focus-blur/article.md
+++ b/2-ui/4-forms-controls/2-focus-blur/article.md
@@ -196,7 +196,7 @@ This will work:
 
 Second, there are `focusin` and `focusout` events -- exactly the same as `focus/blur`, but they bubble.
 
-Note that they must be assigned using `elem.addEventListener` or HTML attribute `on<event>`, not `elem.on<event>`.
+Note that they must be assigned using `elem.addEventListener` or HTML-attribute `on<event>`, not `elem.on<event>`.
 
 So here's another working variant:
 

--- a/2-ui/4-forms-controls/2-focus-blur/article.md
+++ b/2-ui/4-forms-controls/2-focus-blur/article.md
@@ -196,7 +196,7 @@ This will work:
 
 Second, there are `focusin` and `focusout` events -- exactly the same as `focus/blur`, but they bubble.
 
-Note that they must be assigned using `elem.addEventListener`, not `on<event>`.
+Note that they must be assigned using `elem.addEventListener` or HTML attribute `on<event>`, not `elem.on<event>`.
 
 So here's another working variant:
 


### PR DESCRIPTION
add note about html attribute usage for focusin and focusout events, since they work unlike elem.on<event>