### PR TITLE
Update article.md to expand on property order in objects

### DIFF
--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -475,14 +475,14 @@ Now it works as intended.
 If an object has both integer properties and non-integer properties, the integer properties will appear first, regardless of creation order.
 
 ```js run
-let favoriteGames = {};
-favoriteGames.year = 1996;
-favoriteGames.author = "John Smith";
-favoriteGames[3] = "Crash Bandicoot";
-favoriteGames[2] = "Super Mario 64";
-favoriteGames[1] = "Quake";
+let favoriteGamesTopThree = {};
+favoriteGamesTopThree.year = 1996;
+favoriteGamesTopThree.author = "John Smith";
+favoriteGamesTopThree[3] = "Crash Bandicoot";
+favoriteGamesTopThree[2] = "Super Mario 64";
+favoriteGamesTopThree[1] = "Quake";
 
-for (let prop in favoriteGames) {
+for (let prop in favoriteGamesTopThree) {
   alert( prop ); // 1, 2, 3, year, author
 }
 ```

--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -392,7 +392,7 @@ Also, we could use another variable name here instead of `key`. For instance, `"
 
 Are objects ordered? In other words, if we loop over an object, do we get all properties in the same order they were added? Can we rely on this?
 
-The short answer is: "ordered in a special fashion": integer properties are sorted, others appear in creation order. The details follow.
+The short answer is: "ordered in a special fashion": Integer properties appear first in sorted order, then other properties appear in creation order. The details follow.
 
 As an example, let's consider an object with the phone codes:
 
@@ -471,6 +471,21 @@ for (let code in codes) {
 ```
 
 Now it works as intended.
+
+If an object has both integer properties and non-integer properties, the integer properties will appear first, regardless of creation order.
+
+```js run
+let favoriteGames = {};
+favoriteGames.year = 1996;
+favoriteGames.author = "John Smith";
+favoriteGames[3] = "Crash Bandicoot";
+favoriteGames[2] = "Super Mario 64";
+favoriteGames[1] = "Quake";
+
+for (let prop in favoriteGames) {
+  alert( prop ); // 1, 2, 3, year, author
+}
+```
 
 ## Summary
 


### PR DESCRIPTION
Current article does mention integer properties, but it's not explicit that these appear first in the object and the existing example doesn't feature this situation. I've made the wording more explicit and added a small, if somewhat contrived, example of this situation.