### PR TITLE
Correct typo in Export and Import article

### DIFF
--- a/1-js/13-modules/02-import-export/article.md
+++ b/1-js/13-modules/02-import-export/article.md
@@ -99,7 +99,7 @@ Well, there are few reasons.
 ```smart header="Don't be afraid to import too much"
 Modern build tools, such as [webpack](https://webpack.js.org/) and others, bundle modules together and optimize them to speedup loading. They also removed unused imports.
 
-For instance, if you `import * as library` from a huge code library, and then use only few methods, then unused ones [will not be included](https://github.com/webpack/webpack/tree/main/examples/harmony-unused#examplejs) into the optimzed bundle.
+For instance, if you `import * as library` from a huge code library, and then use only few methods, then unused ones [will not be included](https://github.com/webpack/webpack/tree/main/examples/harmony-unused#examplejs) into the optimized bundle.
 ```
 
 ## Import "as"


### PR DESCRIPTION
Just a small typo that I found while going over the [Export and Import](https://javascript.info/import-export) article.