### PR TITLE
tiny changes: spelling and consistency

### DIFF
--- a/1-js/13-modules/02-import-export/article.md
+++ b/1-js/13-modules/02-import-export/article.md
@@ -63,7 +63,7 @@ export {sayHi, sayBye}; // a list of exported variables
 
 ...Or, technically we could put `export` above functions as well.
 
-## Import *
+## Import "*"
 
 Usually, we put a list of what to import in curly braces `import {...}`, like this:
 
@@ -99,7 +99,7 @@ Well, there are few reasons.
 ```smart header="Don't be afraid to import too much"
 Modern build tools, such as [webpack](https://webpack.js.org/) and others, bundle modules together and optimize them to speedup loading. They also removed unused imports.
 
-For instance, if you `import * as library` from a huge code library, and then use only few methods, then unused ones [will not be included](https://github.com/webpack/webpack/tree/main/examples/harmony-unused#examplejs) into the optimzed bundle.
+For instance, if you `import * as library` from a huge code library, and then use only few methods, then unused ones [will not be included](https://github.com/webpack/webpack/tree/main/examples/harmony-unused#examplejs) into the optimized bundle.
 ```
 
 ## Import "as"


### PR DESCRIPTION
Spelling:
`optimzed` -> `optimized`

Consistency: 
`Import *` -> `Import "*"` 

For consistency with `Import "as" and `Export "as"`. Also -- as-is it looks like `Import *` is just `Import` with a footnote. It had me confused for several minutes.

NB: This shouldn't affect links, since neither `*` nor quotes are reflected in the link fragment. The URL is simply `/import-export#import` either way.