### PR TITLE
Add comma for better readability

### DIFF
--- a/1-js/05-data-types/10-destructuring-assignment/article.md
+++ b/1-js/05-data-types/10-destructuring-assignment/article.md
@@ -308,7 +308,7 @@ alert(height); // 200
 
 Just like with arrays or function parameters, default values can be any expressions or even function calls. They will be evaluated if the value is not provided.
 
-In the code below `prompt` asks for `width`, but not for `title`:
+In the code below, `prompt` asks for `width`, but not for `title`:
 
 ```js run
 let options = {
@@ -420,7 +420,7 @@ alert( title ); // Menu
 
 If an object or an array contain other nested objects and arrays, we can use more complex left-side patterns to extract deeper portions.
 
-In the code below `options` has another object in the property `size` and an array in the property `items`. The pattern on the left side of the assignment has the same structure to extract values from them:
+In the code below, `options` has another object in the property `size` and an array in the property `items`. The pattern on the left side of the assignment has the same structure to extract values from them:
 
 ```js run
 let options = {


### PR DESCRIPTION
I think a comma (,) after every "In the code below" makes the text more readable. For example, there is a line that says:

In the code below `prompt` asks for `width`, but not for `title`:

It can be mistakenly interpreted as "look for the code below `prompt()` " , instead of "look how `prompt` works in the code below" Have a good day :)