### PR TITLE
Fix wording

### DIFF
--- a/1-js/02-first-steps/13-while-for/3-which-value-for/solution.md
+++ b/1-js/02-first-steps/13-while-for/3-which-value-for/solution.md
@@ -6,7 +6,7 @@ for (let i = 0; i < 5; ++i) alert( i );
 for (let i = 0; i < 5; i++) alert( i );
 ```
 
-That can be easily deducted from the algorithm of `for`:
+That can be easily deduced from the algorithm of `for`:
 
 1. Execute once `i = 0` before everything (begin).
 2. Check the condition `i < 5`


### PR DESCRIPTION
Changed 'deducted' -> 'deduced'. Deduct means to subtract, while deduce means to conclude through reasoning.