### PR TITLE
Fixed syntax typo in slice, substring, substr

### DIFF
--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -328,7 +328,7 @@ alert( "Wid*!*get*/!*".endsWith("get") ); // true, "Widget" ends with "get"
 
 There are 3 methods in JavaScript to get a substring: `substring`, `substr` and `slice`.
 
-`str.slice(start [, end])`
+`str.slice(start, end)`
 : Returns the part of the string from `start` to (but not including) `end`.
 
     For instance:
@@ -355,7 +355,7 @@ There are 3 methods in JavaScript to get a substring: `substring`, `substr` and 
     alert( str.slice(-4, -1) ); // 'gif'
     ```
 
-`str.substring(start [, end])`
+`str.substring(start, end)`
 : Returns the part of the string *between* `start` and `end` (not including `end`).
 
     This is almost the same as `slice`, but it allows `start` to be greater than `end` (in this case it simply swaps `start` and `end` values).
@@ -377,7 +377,7 @@ There are 3 methods in JavaScript to get a substring: `substring`, `substr` and 
 
     Negative arguments are (unlike slice) not supported, they are treated as `0`.
 
-`str.substr(start [, length])`
+`str.substr(start, length)`
 : Returns the part of the string from `start`, with the given `length`.
 
     In contrast with the previous methods, this one allows us to specify the `length` instead of the ending position:


### PR DESCRIPTION
# Syntax Typo Fix

There is a **typo** in the the syntax of **slice** and **substring** and **substr** methods.
It incorrectly displays (start [,end]) which is wrong. It should be (start, end).

Issue: https://github.com/javascript-tutorial/en.javascript.info/issues/3446
@iliakan 
**Reference:** 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr