### PR TITLE
Update article.md - comment on skipping arguments

### DIFF
--- a/1-js/05-data-types/12-json/article.md
+++ b/1-js/05-data-types/12-json/article.md
@@ -305,6 +305,7 @@ let user = {
   }
 };
 
+// we can use null or undefined here to skip over an optional parameter
 alert(JSON.stringify(user, null, 2));
 /* two-space indents:
 {


### PR DESCRIPTION
following the lessons, this is the first time we see skipping of optional variables. So I added an extra comment to point that out explicitly. 

also i guess we always need to refer to documents to know what a method's optional argument allows or considered rejected values - but it seems that passing undefined is the best approach to fallback internal default values (if implemented).