### PR TITLE
Fix missing semicolon

### DIFF
--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -144,7 +144,7 @@ Here's exactly what happens in our case:
 // for (let i = 0; i < 3; i++) alert(i)
 
 // run begin
-let i = 0
+let i = 0;
 // if condition → run body and run step
 if (i < 3) { alert(i); i++ }
 // if condition → run body and run step


### PR DESCRIPTION
Fix the missing semicolon in an example in the JavaScript Fundamentals article on "Loops: while and for"

Though semicolons in JavaScript are optional, it is best practice to include them.