### PR TITLE
UI description change: edit breakpoint condition

### DIFF
--- a/1-js/03-code-quality/01-debugging-chrome/article.md
+++ b/1-js/03-code-quality/01-debugging-chrome/article.md
@@ -63,7 +63,7 @@ We can always find a list of breakpoints in the right panel. That's useful when 
 - ...And so on.
 
 ```smart header="Conditional breakpoints"
-*Right click* on the line number allows to create a *conditional* breakpoint. It only triggers when the given expression, that you should provide when you create it, is truthy.
+Clicking on the pen icon (*Edit condition*) allows to create a *conditional* breakpoint. It only triggers when the given expression, that you should provide when you create it, is truthy.
 
 That's handy when we need to stop only for a certain variable value or for certain function parameters.
 ```


### PR DESCRIPTION
Seems like the UI of the dev tools changed(?!).
Creating conditional breakpoints now works via pen icon.