### PR TITLE
change `user` to `userAdmin`

### DIFF
--- a/1-js/04-object-basics/07-optional-chaining/article.md
+++ b/1-js/04-object-basics/07-optional-chaining/article.md
@@ -180,7 +180,7 @@ userGuest.admin?.(); // nothing happens (no such method)
 */!*
 ```
 
-Here, in both lines we first use the dot (`userAdmin.admin`) to get `admin` property, because we assume that the `user` object exists, so it's safe read from it.
+Here, in both lines we first use the dot (`userAdmin.admin`) to get `admin` property, because we assume that the `userAdmin` object exists, so it's safe read from it.
 
 Then `?.()` checks the left part: if the `admin` function exists, then it runs (that's so for `userAdmin`). Otherwise (for `userGuest`) the evaluation stops without errors.
 


### PR DESCRIPTION
I found one typo in the topic optional chaining. 

snippet: 
```
let userAdmin = {
  admin() {
    alert("I am admin");
  }
};
```

In the below phrase:

> Here, in both lines we first use the dot (`userAdmin.admin`) to get the `admin` property, because we assume that the `userAdmin` object exists, so it's safe read from it.


`user` should be `userAdmin` cause the obj's name is `userAdmin` not `user`.

PS: Thank you for these great docs! A lot of information are well cleared.

Closes: #3499 

