### PR TITLE
Fixes #3509 - updated wording for default parameters location

### DIFF
--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -265,7 +265,7 @@ function showMessage(from, text) {
 
 ### Alternative default parameters
 
-Sometimes it makes sense to assign default values for parameters at a later stage after the function declaration.
+Sometimes it makes sense to assign default values for parameters at a later stage within the function body.
 
 We can check if the parameter is passed during the function execution, by comparing it with `undefined`:
 


### PR DESCRIPTION
Changes the wording to better describe the location of the application of manual default parameters within the body of a function declaration.
