### PR TITLE
fixed map-set article

### DIFF
--- a/1-js/05-data-types/07-map-set/article.md
+++ b/1-js/05-data-types/07-map-set/article.md
@@ -294,8 +294,8 @@ That's for compatibility with `Map` where the callback passed `forEach` has thre
 
 The same methods `Map` has for iterators are also supported:
 
-- [`set.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/keys) -- returns an iterable object for values,
-- [`set.values()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values) -- same as `set.keys()`, for compatibility with `Map`,
+- [`set.values()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values) -- returns an iterable object for values,
+- [`set.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/keys) -- same as `set.values()`, for compatibility with `Map`,
 - [`set.entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/entries) -- returns an iterable object for entries `[value, value]`, exists for compatibility with `Map`.
 
 ## Summary


### PR DESCRIPTION
hii, i think saying that `set.values()` was added for compatibility with `Map` is a little incorrect, because `Set` collection has only values without keys, so it will be more better to say that `set.keys()` was added for compatibility.

i did same PR to russian repository too. [https://github.com/javascript-tutorial/ru.javascript.info/pull/1867](https://github.com/javascript-tutorial/ru.javascript.info/pull/1867)
