### PR TITLE
Not exactly a correct statement in the article

### DIFF
--- a/1-js/02-first-steps/08-operators/article.md
+++ b/1-js/02-first-steps/08-operators/article.md
@@ -75,7 +75,6 @@ For example, a square root is an exponentiation by ½:
 
 ```js run
 alert( 4 ** (1/2) ); // 2 (power of 1/2 is the same as a square root)
-alert( 8 ** (1/3) ); // 2 (power of 1/3 is the same as a cubic root)
 ```
 
 


### PR DESCRIPTION
[Basic operators, maths](https://javascript.info/operators)
--
Code:
```javascript
alert( 8 ** (1/3) ); // 2 (power of 1/3 is the same as a cubic root)
```

In fact, **it's not the same as a cubic root**. 

In case the base of the power is a negative number $`\Huge{-n^{\frac{1}{3}}}`$, the result of the expression will be `NaN`:

```javascript
alert((-8) ** (1/3)) // NaN
```

...Although $`\large{\sqrt[3]{-8}} = -2`$

I believe this unfortunate example should be deleted, there is a special method for taking the cube root of a number, `Math.cbrt()`, which can deal with negative numbers:

```javascript
Math.cbrt(-8) // -2
```