### PR TITLE
Odd statement

### DIFF
--- a/1-js/04-object-basics/01-object/article.md
+++ b/1-js/04-object-basics/01-object/article.md
@@ -352,7 +352,7 @@ alert( "test" in obj ); // true, the property does exist!
 
 In the code above, the property `obj.test` technically exists. So the `in` operator works right.
 
-Situations like this happen very rarely, because `undefined` should not be explicitly assigned. We mostly use `null` for "unknown" or "empty" values. So the `in` operator is an exotic guest in the code.
+Situations like this happen very rarely, because `undefined` should not be explicitly assigned. We mostly use `null` for "unknown" or "empty" values.
 
 
 ## The "for..in" loop [#forin]


### PR DESCRIPTION
# [Objects](https://javascript.info/object)

>  ...So the `in` operator is an exotic guest in the code.

On the contrary, the `in` operator <ins>should</ins> be used in case we need to check if an object has a certain property, using `in` is quite common and not exotic at all. And this method will be the safest, unlike the comparison with `undefined`, which is implied in the article as "not exotic, widespread". 

Or, it's a typo, and the article implied that the exotic guest in the code was a property with a value of `undefined`?