### PR TITLE
Redundant code in the "Event Delegation" article

### DIFF
--- a/2-ui/2-events/03-event-delegation/article.md
+++ b/2-ui/2-events/03-event-delegation/article.md
@@ -131,7 +131,6 @@ The handler reads the attribute and executes the method. Take a look at the work
 <script>
   class Menu {
     constructor(elem) {
-      this._elem = elem;
       elem.onclick = this.onClick.bind(this); // (*)
     }
 


### PR DESCRIPTION
# [Event delegation](https://javascript.info/event-delegation)

Code:

```javascript
  class Menu {
    constructor(elem) {
      this._elem = elem; // <=====
      elem.onclick = this.onClick.bind(this); 
    }

    save() {
      alert('saving');
    }

    load() {
      alert('loading');
    }

    search() {
      alert('searching');
    }

    onClick(event) {
      let action = event.target.dataset.action;
      if (action) {
        this[action]();
      }
    };
  }
```

The marked line is redundant, it is not used anywhere else in the code. This PR removes it.