### PR TITLE
Wrong solution of the task "Random number from min to max"

### DIFF
--- a/1-js/05-data-types/02-number/9-random-int-min-max/solution.md
+++ b/1-js/05-data-types/02-number/9-random-int-min-max/solution.md
@@ -27,22 +27,7 @@ Now we can clearly see that `1` gets twice less values than `2`. And the same wi
 
 # The correct solution
 
-There are many correct solutions to the task. One of them is to adjust interval borders. To ensure the same intervals, we can generate values from `0.5 to 3.5`, thus adding the required probabilities to the edges:
-
-```js run
-*!*
-function randomInteger(min, max) {
-  // now rand is from  (min-0.5) to (max+0.5)
-  let rand = min - 0.5 + Math.random() * (max - min + 1);
-  return Math.round(rand);
-}
-*/!*
-
-alert( randomInteger(1, 3) );
-```
-
-An alternative way could be to use `Math.floor` for a random number from `min` to `max+1`:
-
+There are many correct solutions to the task. One of them is to use `Math.floor` for a random number from `min` to `max+1`:
 ```js run
 *!*
 function randomInteger(min, max) {


### PR DESCRIPTION
Current solution of the task, considered as the correct one:

```javascript
function randomInteger(min, max) {
  // now rand is from  (min-0.5) to (max+0.5)
  let rand = min - 0.5 + Math.random() * (max - min + 1);
  return Math.round(rand);
}
```

In case we have $`\large{0}`$ as `min`, we may get $`\large{-0}`$ as a random number.

The incorrectness of this solution can be proved by running the following code:
```javascript
for (let i = 0; i < 1000; i++) console.log( randomInteger(0, 1) );

// Among the results of repeatedly running the randomInteger(0, 1), there is definitely going to be -0. //
```

The alternative solution to this problem, just below, is completely correct, so I suggest using only it:

```javascript
function randomInteger(min, max) {
  // here rand is from min to (max+1)
  let rand = min + Math.random() * (max + 1 - min);
  return Math.floor(rand);
}
```