### PR TITLE
Clarification about `console.log()` and `console.dir()` in Firefox

### DIFF
--- a/2-ui/1-document/05-basic-dom-node-properties/article.md
+++ b/2-ui/1-document/05-basic-dom-node-properties/article.md
@@ -97,7 +97,7 @@ But for DOM elements they are different:
 - `console.log(elem)` shows the element DOM tree.
 - `console.dir(elem)` shows the element as a DOM object, good to explore its properties.
 
-Try it on `document.body`.
+Try it on `document.body`. You'll see the difference in all modern browsers (except Firefox, where `console.log(elem)` and `console.dir(elem)` show the same thing - the element as a DOM object).
 ```
 
 ````smart header="IDL in the spec"


### PR DESCRIPTION
# [Node properties: type, tag and contents](https://javascript.info/basic-dom-node-properties)

> ![image](https://github.com/javascript-tutorial/en.javascript.info/assets/74434545/66458f26-5a09-4f1e-8c1c-52b67fbb041d)

Starting from version **57.0**, Firefox responds to `console.log(elem)` and `console.dir(elem)` in the same way - outputs `elem` as a DOM object. I've added a clarification on this point.

![image](https://github.com/javascript-tutorial/en.javascript.info/assets/74434545/5035dcb9-b7e8-4e01-af68-156be48bb451)

![image](https://github.com/javascript-tutorial/en.javascript.info/assets/74434545/71c52e04-09a0-444c-a6fa-fe203847af52)
