### PR TITLE
Misleading argument in the example

### DIFF
--- a/2-ui/2-events/01-introduction-browser-events/article.md
+++ b/2-ui/2-events/01-introduction-browser-events/article.md
@@ -414,7 +414,7 @@ The method `handleEvent` does not have to do all the job by itself. It can call 
     handleEvent(event) {
       // mousedown -> onMousedown
       let method = 'on' + event.type[0].toUpperCase() + event.type.slice(1);
-      this[method](event);
+      this[method]();
     }
 
     onMousedown() {


### PR DESCRIPTION
# [Introduction to browser events](https://javascript.info/introduction-browser-events)

Code: 

```javascript
  class Menu {
    handleEvent(event) {
      let method = 'on' + event.type[0].toUpperCase() + event.type.slice(1);
      this[method](event); // <=====
    }

    onMousedown() {
      elem.innerHTML = "Mouse button pressed";
    }

    onMouseup() {
      elem.innerHTML += "...and released.";
    }
  }

  let menu = new Menu();
  elem.addEventListener('mousedown', menu);
  elem.addEventListener('mouseup', menu);
  ```

There is no need to pass the `event` argument in the expression `this[method](event)`, because the passed argument is not used in further code. This may mislead the reader.