### PR TITLE
New flag in regular expressions: `d`

### DIFF
--- a/9-regular-expressions/01-regexp-introduction/article.md
+++ b/9-regular-expressions/01-regexp-introduction/article.md
@@ -39,9 +39,9 @@ let regexp = new RegExp(`<${tag}>`); // same as /<h2>/ if answered "h2" in the p
 
 ## Flags
 
-Regular expressions may have flags that affect the search.
+Regular expressions may have flags that affect the search or provide additional information.
 
-There are only 6 of them in JavaScript:
+There are only 7 of them in JavaScript:
 
 `pattern:i`
 : With this flag the search is case-insensitive: no difference between `A` and `a` (see the example below).
@@ -60,6 +60,9 @@ There are only 6 of them in JavaScript:
 
 `pattern:y`
 : "Sticky" mode: searching at the exact position in the text  (covered in the chapter <info:regexp-sticky>)
+
+`pattern:d`
+: With this flag, the result of the regular expression is placed in an array which contains additional information about the regular expression, such as the start and end indices of the substring. This flag does not change the behavior of the regular expression, it just provides additional information.
 
 ```smart header="Colors"
 From here on the color scheme is:
@@ -170,7 +173,7 @@ Full information about the methods is given in the article <info:regexp-methods>
 
 ## Summary
 
-- A regular expression consists of a pattern and optional flags: `pattern:g`, `pattern:i`, `pattern:m`, `pattern:u`, `pattern:s`, `pattern:y`.
+- A regular expression consists of a pattern and optional flags: `pattern:g`, `pattern:i`, `pattern:m`, `pattern:u`, `pattern:s`, `pattern:y`, `pattern:d`.
 - Without flags and special symbols  (that we'll study later), the search by a regexp is the same as a substring search.
 - The method `str.match(regexp)` looks for matches: all of them if there's `pattern:g` flag, otherwise, only the first one.
 - The method `str.replace(regexp, replacement)` replaces matches found using `regexp` with `replacement`: all of them if there's `pattern:g` flag, otherwise only the first one.


### PR DESCRIPTION
# [Patterns and flags](https://javascript.info/regexp-introduction)

ECMAScript 2022 introduced a new flag for regular expressions: `d`. Here are some sources describing the behavior of this flag:

- https://stackoverflow.com/a/73947884
- https://www.dotnetcurry.com/javascript/ecmascript-2022#:~:text=RegExp%20Match%20Indices
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices#:~:text=The%20d%20flag%20indicates%20that%20the%20result%20of%20a%20regular%20expression%20match%20should%20contain%20the%20start%20and%20end%20indices%20of%20the%20substrings%20of%20each%20capture%20group.%20It%20does%20not%20change%20the%20regex's%20interpretation%20or%20matching%20behavior%20in%20any%20way,%20but%20only%20provides%20additional%20information%20in%20the%20matching%20result.