### PR TITLE
Incorrect information regarding access to the `document` of the `iframe` 

### DIFF
--- a/3-frames-and-windows/03-cross-window-communication/article.md
+++ b/3-frames-and-windows/03-cross-window-communication/article.md
@@ -48,18 +48,16 @@ For instance, let's try reading and writing to `<iframe>` from another origin:
 *!*
     let iframeWindow = iframe.contentWindow; // OK
 */!*
-    try {
-      // ...but not to the document inside it
+
+    // ...but when we try to access the document
+
 *!*
-      let doc = iframe.contentDocument; // ERROR
+    let doc = iframe.contentDocument; // ...we'll get null
 */!*
-    } catch(e) {
-      alert(e); // Security Error (another origin)
-    }
 
     // also we can't READ the URL of the page in iframe
     try {
-      // Can't read URL from the Location object
+      // can't read URL from the Location object
 *!*
       let href = iframe.contentWindow.location.href; // ERROR
 */!*
@@ -77,7 +75,7 @@ For instance, let's try reading and writing to `<iframe>` from another origin:
 </script>
 ```
 
-The code above shows errors for any operations except:
+The code above shows `null` or error for any operations except:
 
 - Getting the reference to the inner window `iframe.contentWindow` - that's allowed.
 - Writing to `location`.


### PR DESCRIPTION
# [Cross-window communication](https://javascript.info/cross-window-communication)

Code:

```javascript
<script>
  iframe.onload = function() {
    // we can get the reference to the inner window
    let iframeWindow = iframe.contentWindow; // OK
    try {
      // ...but not to the document inside it
      let doc = iframe.contentDocument; // ERROR // 🟢
    } catch(e) {
      alert(e); // Security Error (another origin)
    }

    // also we can't READ the URL of the page in iframe
    try {
      // Can't read URL from the Location object
      let href = iframe.contentWindow.location.href; // ERROR
    } catch(e) {
      alert(e); // Security Error
    }

    // ...we can WRITE into location (and thus load something else into the iframe)!
    iframe.contentWindow.location = '/'; // OK

    iframe.onload = null; // clear the handler, not to run it after the location change
  };
</script>
```

In the line labeled `🟢`, we will not get any error when trying to access `iframe.contentDocument`.

MDN: [HTMLIFrameElement: contentDocument property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentDocument):

> **If the iframe and the iframe's parent document are [Same Origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy), returns a [Document](https://developer.mozilla.org/en-US/docs/Web/API/Document)** (that is, the active document in the inline frame's nested browsing context), $`\Huge\textcolor{red}{else}`$ $`\Huge\textcolor{red}{returns}`$ $`\Huge\textcolor{red}{null}`$.