### PR TITLE
Missing comma in the example

### DIFF
--- a/1-js/05-data-types/12-json/article.md
+++ b/1-js/05-data-types/12-json/article.md
@@ -441,11 +441,11 @@ Here are typical mistakes in hand-written JSON (sometimes we have to write it fo
 
 ```js
 let json = `{
-  *!*name*/!*: "John",                     // mistake: property name without quotes
-  "surname": *!*'Smith'*/!*,               // mistake: single quotes in value (must be double)
-  *!*'isAdmin'*/!*: false                  // mistake: single quotes in key (must be double)
-  "birthday": *!*new Date(2000, 2, 3)*/!*, // mistake: no "new" is allowed, only bare values
-  "friends": [0,1,2,3]              // here all fine
+  *!*name*/!*: "John",                      // mistake: property name without quotes
+  "surname": *!*'Smith'*/!*,                // mistake: single quotes in value (must be double)
+  *!*'isAdmin'*/!*: false,                  // mistake: single quotes in key (must be double)
+  "birthday": *!*new Date(2000, 2, 3)*/!*,  // mistake: no "new" is allowed, only bare values
+  "friends": [0,1,2,3]               // here all fine
 }`;
 ```
 


### PR DESCRIPTION
# [JSON methods, toJSON](https://javascript.info/json)

```javascript
let json = `{
  *!*name*/!*: "John",                      // mistake: property name without quotes
  "surname": *!*'Smith'*/!*,                // mistake: single quotes in value (must be double)
  *!*'isAdmin'*/!*: false                  // mistake: single quotes in key (must be double)
  "birthday": *!*new Date(2000, 2, 3)*/!*,  // mistake: no "new" is allowed, only bare values
  "friends": [0,1,2,3]               // here all fine
}`;
```

There should be a comma after `'isAdmin': false`.