### PR TITLE
Add space between "while" and parenthesis

### DIFF
--- a/1-js/02-first-steps/13-while-for/article.md
+++ b/1-js/02-first-steps/13-while-for/article.md
@@ -404,7 +404,7 @@ We covered 3 types of loops:
 - `do..while` -- The condition is checked after each iteration.
 - `for (;;)` -- The condition is checked before each iteration, additional settings available.
 
-To make an "infinite" loop, usually the `while(true)` construct is used. Such a loop, just like any other, can be stopped with the `break` directive.
+To make an "infinite" loop, usually the `while (true)` construct is used. Such a loop, just like any other, can be stopped with the `break` directive.
 
 If we don't want to do anything in the current iteration and would like to forward to the next one, we can use the `continue` directive.
 


### PR DESCRIPTION
Putting space between for/if/while and the parenthesis is recommended to avoid confusion with function calls.
javascript.info follows this recommendation, but I found and fixed an exception.