### PR TITLE
Outdated link

### DIFF
--- a/1-js/01-getting-started/2-manuals-specifications/article.md
+++ b/1-js/01-getting-started/2-manuals-specifications/article.md
@@ -5,7 +5,7 @@ This book is a *tutorial*. It aims to help you gradually learn the language. But
 
 ## Specification
 
-[The ECMA-262 specification](https://www.ecma-international.org/publications/standards/Ecma-262.htm) contains the most in-depth, detailed and formalized information about JavaScript. It defines the language.
+[The ECMA-262 specification](https://www.ecma-international.org/publications-and-standards/standards/ecma-262/) contains the most in-depth, detailed and formalized information about JavaScript. It defines the language.
 
 But being that formalized, it's difficult to understand at first. So if you need the most trustworthy source of information about the language details, the specification is the right place. But it's not for everyday use.
 


### PR DESCRIPTION
# [Manuals and specifications](https://javascript.info/manuals-specifications)

An outdated link was provided in the article:

![image](https://github.com/javascript-tutorial/en.javascript.info/assets/74434545/a960eed1-eea3-479f-8b58-406b28eba3fc)
