### PR TITLE
fix: fix the example of proxy limitations for `Map`

### DIFF
--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -816,8 +816,8 @@ Fortunately, there's a way to fix it:
 let map = new Map();
 
 let proxy = new Proxy(map, {
-  get(target, prop, receiver) {
-    let value = Reflect.get(...arguments);
+  get(target, prop) {
+    let value = Reflect.get(target, prop);
 *!*
     return typeof value == 'function' ? value.bind(target) : value;
 */!*


### PR DESCRIPTION
The previous example had a bug where you couldn't call `size` property from the proxied `Map` and doing such would raise an error of:
```
Uncaught TypeError: Method get Map.prototype.size called on incompatible receiver #<Map>
```

This PR provides a more general-purpose, yet simple example that works with both methods and properties.