### PR TITLE
Update solution.md

### DIFF
--- a/1-js/11-async/08-async-await/01-rewrite-async/solution.md
+++ b/1-js/11-async/08-async-await/01-rewrite-async/solution.md
@@ -29,5 +29,5 @@ Notes:
     }
     ```
 
-    Then the outer code would have to `await` for that promise to resolve. In our case it doesn't matter.
+    Then the outer code would have to `.then()` for that promise to resolve. In our case it doesn't matter.
 4. The error thrown from `loadJson` is handled by `.catch`. We can't use `await loadJson(…)` there, because we're not in an `async` function.


### PR DESCRIPTION
Edited the sentence saying the outer code had to await to saying the outer code had to .then() as the outer code is not inside an async function.