### PR TITLE
Update article.md: Small correction

### DIFF
--- a/1-js/11-async/01-callbacks/article.md
+++ b/1-js/11-async/01-callbacks/article.md
@@ -70,7 +70,7 @@ function loadScript(src, *!*callback*/!*) {
   script.src = src;
 
 *!*
-  script.onload = () => callback(script);
+  script.onload = () => callback();
 */!*
 
   document.head.append(script);


### PR DESCRIPTION
The anonymous function passed to loadScript doesn't accept any arguments but the definition passes the callback the script tag which isn't necessary at all and may induce confusion. 

It makes perfect sense in successive examples, might have been a typo.