### PR TITLE
Update __proto__ to Object.create

### DIFF
--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -708,10 +708,11 @@ let userProxy = new Proxy(user, {
 });
 
 *!*
-let admin = {
-  __proto__: userProxy,
-  _name: "Admin"
-};
+let admin = Object.create(userProxy, {
+  _name: {
+    value: "Admin"
+  }
+});
 
 // Expected: Admin
 alert(admin.name); // outputs: Guest (?!?)
@@ -757,10 +758,11 @@ let userProxy = new Proxy(user, {
 });
 
 
-let admin = {
-  __proto__: userProxy,
-  _name: "Admin"
-};
+let admin = Object.create(userProxy, {
+  _name: {
+    value: "Admin"
+  }
+});
 
 *!*
 alert(admin.name); // Admin


### PR DESCRIPTION
replaced `__proto__` property way of instantiating objects based on a prototype with `Object.create`.