### PR TITLE
Remove same line variable declaration

### DIFF
--- a/1-js/02-first-steps/04-variables/1-hello-variables/solution.md
+++ b/1-js/02-first-steps/04-variables/1-hello-variables/solution.md
@@ -1,7 +1,8 @@
 In the code below, each line corresponds to the item in the task list.
 
 ```js run
-let admin, name; // can declare two variables at once
+let admin;
+let name;
 
 name = "John";
 


### PR DESCRIPTION
Earlier in the tutorial it was stated that using same line variable declaration is bad practice, however in the solution they were on the same line. I put them on separate lines for clarity.