### PR TITLE
fix: possible JS error while convert Symbol to number

### DIFF
--- a/1-js/99-js-misc/01-proxy/02-array-negative/solution.md
+++ b/1-js/99-js-misc/01-proxy/02-array-negative/solution.md
@@ -4,7 +4,8 @@ let array = [1, 2, 3];
 
 array = new Proxy(array, {
   get(target, prop, receiver) {
-    if (prop < 0) {
+    // prop can be string or Symbol
+    if (typeof prop === "string" && prop < 0) {
       // even if we access it like arr[1]
       // prop is a string, so need to convert it to number
       prop = +prop + target.length;


### PR DESCRIPTION
in the solution, prop can be string or Symbol. 

while prop is a symbol;
    prop < 0         
causes JS Error. 
"Error: Cannot convert a Symbol value to a number" And Reflect.set never executed to handle Symbol prop.