### PR TITLE
Replace assignment with equals in Truncate the text task

### DIFF
--- a/1-js/05-data-types/03-string/3-truncate/task.md
+++ b/1-js/05-data-types/03-string/3-truncate/task.md
@@ -11,7 +11,7 @@ The result of the function should be the truncated (if needed) string.
 For instance:
 
 ```js
-truncate("What I'd like to tell on this topic is:", 20) = "What I'd like to te…"
+truncate("What I'd like to tell on this topic is:", 20) == "What I'd like to te…"
 
-truncate("Hi everyone!", 20) = "Hi everyone!"
+truncate("Hi everyone!", 20) == "Hi everyone!"
 ```


### PR DESCRIPTION
Replace the assignment operator `=` with the equality comparison `==` in both examples in the 'Truncate the text' task.