### PR TITLE
fix square brackets

### DIFF
--- a/1-js/05-data-types/12-json/article.md
+++ b/1-js/05-data-types/12-json/article.md
@@ -405,7 +405,7 @@ To decode a JSON-string, we need another method named [JSON.parse](mdn:js/JSON/p
 
 The syntax:
 ```js
-let value = JSON.parse(str, [reviver]);
+let value = JSON.parse(str[, reviver]);
 ```
 
 str

--- a/1-js/08-prototypes/04-prototype-methods/article.md
+++ b/1-js/08-prototypes/04-prototype-methods/article.md
@@ -14,7 +14,7 @@ The only usage of `__proto__`, that's not frowned upon, is as a property when cr
 
 Although, there's a special method for this too:
 
-- [Object.create(proto, [descriptors])](mdn:js/Object/create) -- creates an empty object with given `proto` as `[[Prototype]]` and optional property descriptors.
+- [Object.create(proto[, descriptors])](mdn:js/Object/create) -- creates an empty object with given `proto` as `[[Prototype]]` and optional property descriptors.
 
 For instance:
 
@@ -201,7 +201,7 @@ alert(Object.keys(chineseDictionary)); // hello,bye
 - To create an object with the given prototype, use:
 
     - literal syntax: `{ __proto__: ... }`, allows to specify multiple properties
-    - or [Object.create(proto, [descriptors])](mdn:js/Object/create), allows to specify property descriptors.
+    - or [Object.create(proto[, descriptors])](mdn:js/Object/create), allows to specify property descriptors.
 
     The `Object.create` provides an easy way to shallow-copy an object with all descriptors:
 


### PR DESCRIPTION
if `descriptors` are optional, fixing the parameters in the method will be correct. For example this page -> https://javascript.info/json . Here you can find `let json = JSON.stringify(value[, replacer, space])` line, where `replacer, spaces` are optional.