### PR TITLE
Remove the square brackets "[" and "]" from the syntax

### DIFF
--- a/1-js/05-data-types/05-array-methods/article.md
+++ b/1-js/05-data-types/05-array-methods/article.md
@@ -41,7 +41,7 @@ The [arr.splice](mdn:js/Array/splice) method is a swiss army knife for arrays. I
 The syntax is:
 
 ```js
-arr.splice(start[, deleteCount, elem1, ..., elemN])
+arr.splice(start, deleteCount, elem1, ..., elemN)
 ```
 
 It modifies `arr` starting from the index `start`: removes `deleteCount` elements and then inserts `elem1, ..., elemN` at their place. Returns the array of removed elements.


### PR DESCRIPTION
In the syntax for array splice method, the square bracket should not be present.