### PR TITLE
fix: change the condition within the Animal[Symbol.hasInstance] to match the purpose of the method

### DIFF
--- a/1-js/09-classes/06-instanceof/article.md
+++ b/1-js/09-classes/06-instanceof/article.md
@@ -59,7 +59,7 @@ The algorithm of `obj instanceof Class` works roughly as follows:
     // anything with canEat property is an animal
     class Animal {
       static [Symbol.hasInstance](obj) {
-        if (obj.canEat) return true;
+        if ('canEat' in obj) return true;
       }
     }
 


### PR DESCRIPTION
## Description
According to the comment above the `class Animal`, the purpose of the `Animal[Symbol.hasInstance]` method is to "assume that anything with the canEat property is an animal".  The condition `if (obj.canEat) return true;` doesn't fit the purpose mentioned, because it checks whether `!!obj.canEat === true`. So if we create the object with falsy `canEat` property value (for example: `let obj = { canEat: false};`), then `obj instanceof Animal` will return `false`, meaning that `obj` is not the instance of `Animal` and the condition "anything with the canEat property is an animal" is not true.
I suggest replacing the `if (obj.canEat) return true;` condition with `if ('canEat' in obj) return true;`. The `in` operator returns `true` if the specified property is in the specified object or its prototype chain. With the new condition, `obj instanceof Animal` will return `true` even if the value of the `canEat` property is `false`, which is exactly the same as saying "anything with the canEat property is an animal".
P.S. There is also a `hasOwnProperty()` method, which returns a boolean indicating whether this object has the specified property as its own property (as opposed to inheriting it). This method is not suitable for the implementation `Animal[Symbol.hasInstance]`, because the condition `if (obj.hasOwnProperty('canEat'))` will be truthy only if the property `canEat` is a property of the `obj` itself, but not of its prototypes.
## Links
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty