### PR TITLE
docs: remove eval polyfill.io

### DIFF
--- a/1-js/03-code-quality/06-polyfills/article.md
+++ b/1-js/03-code-quality/06-polyfills/article.md
@@ -73,7 +73,6 @@ JavaScript is a highly dynamic language. Scripts may add/modify any function, ev
 
 Two interesting polyfill libraries are:
 - [core js](https://github.com/zloirock/core-js) that supports a lot, allows to include only needed features.
-- [polyfill.io](https://polyfill.io/) service that provides a script with polyfills, depending on the features and user's browser.
 
 
 ## Summary


### PR DESCRIPTION
polyfill.io has been proven to be evil as it recently started implanting malicious scripts to jump to gambling sites.

https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet