### PR TITLE
minor fix to function name written in explanation

### DIFF
--- a/1-js/06-advanced-functions/10-bind/5-question-use-bind/solution.md
+++ b/1-js/06-advanced-functions/10-bind/5-question-use-bind/solution.md
@@ -1,5 +1,5 @@
 
-The error occurs because `ask` gets functions `loginOk/loginFail` without the object.
+The error occurs because `askPassword` gets functions `loginOk/loginFail` without the object.
 
 When it calls them, they naturally assume `this=undefined`.
 


### PR DESCRIPTION
The code uses the function named 'askPassword' but the text above it explaining the error reason says 'ask' instead of 'askPassword'