### PR TITLE
Update article.md | changes under Comma subheading

### DIFF
--- a/1-js/02-first-steps/08-operators/article.md
+++ b/1-js/02-first-steps/08-operators/article.md
@@ -461,7 +461,7 @@ Here, the first expression `1 + 2` is evaluated and its result is thrown away. T
 ```smart header="Comma has a very low precedence"
 Please note that the comma operator has very low precedence, lower than `=`, so parentheses are important in the example above.
 
-Without them: `a = 1 + 2, 3 + 4` evaluates `+` first, summing the numbers into `a = 3, 7`, then the assignment operator `=` assigns `a = 3`, and the rest is ignored. It's like `(a = 1 + 2), 3 + 4`.
+Without them: `a = 1 + 2, 3 + 4` evaluates `+` first, summing the numbers into `a = 3, 7`, then the assignment operator `=` assigns `a = 7`, and the rest is ignored. It's like `(a = 1 + 2), 3 + 4`.
 ```
 
 Why do we need an operator that throws away everything except the last expression?


### PR DESCRIPTION
Shouldn't "a"  be assigned the value of the later operation(3+4) rather than (1+2).