### PR TITLE
Updated iterables

### DIFF
--- a/1-js/05-data-types/06-iterable/article.md
+++ b/1-js/05-data-types/06-iterable/article.md
@@ -1,12 +1,10 @@
-
 # Iterables
 
-*Iterable* objects are a generalization of arrays. That's a concept that allows us to make any object useable in a `for..of` loop.
+_Iterable_ objects are a generalization of arrays. That's a concept that allows us to make any object useable in a `for..of` loop.
 
 Of course, Arrays are iterable. But there are many other built-in objects, that are iterable as well. For instance, strings are also iterable.
 
 If an object isn't technically an array, but represents a collection (list, set) of something, then `for..of` is a great syntax to loop over it, so let's see how to make it work.
-
 
 ## Symbol.iterator
 
@@ -19,7 +17,7 @@ Like a `range` object that represents an interval of numbers:
 ```js
 let range = {
   from: 1,
-  to: 5
+  to: 5,
 };
 
 // We want the for..of to work:
@@ -28,8 +26,8 @@ let range = {
 
 To make the `range` object iterable (and thus let `for..of` work) we need to add a method to the object named `Symbol.iterator` (a special built-in symbol just for that).
 
-1. When `for..of` starts, it calls that method once (or errors if not found). The method must return an *iterator* -- an object with the method `next`.
-2. Onward, `for..of` works *only with that returned object*.
+1. When `for..of` starts, it calls that method once (or errors if not found). The method must return an _iterator_ -- an object with the method `next`.
+2. Onward, `for..of` works _only with that returned object_.
 3. When `for..of` wants the next value, it calls `next()` on that object.
 4. The result of `next()` must have the form `{done: Boolean, value: any}`, where `done=true` means that the loop is finished, otherwise `value` is the next value.
 
@@ -38,12 +36,11 @@ Here's the full implementation for `range` with remarks:
 ```js run
 let range = {
   from: 1,
-  to: 5
+  to: 5,
 };
 
 // 1. call to for..of initially calls this
-range[Symbol.iterator] = function() {
-
+range[Symbol.iterator] = function () {
   // ...it returns the iterator object:
   // 2. Onward, for..of works only with the iterator object below, asking it for next values
   return {
@@ -58,7 +55,7 @@ range[Symbol.iterator] = function() {
       } else {
         return { done: true };
       }
-    }
+    },
   };
 };
 
@@ -95,7 +92,7 @@ let range = {
     } else {
       return { done: true };
     }
-  }
+  },
 };
 
 for (let num of range) {
@@ -103,7 +100,7 @@ for (let num of range) {
 }
 ```
 
-Now `range[Symbol.iterator]()` returns the `range` object itself:  it has the necessary `next()` method and remembers the current iteration progress in `this.current`. Shorter? Yes. And sometimes that's fine too.
+Now `range[Symbol.iterator]()` returns the `range` object itself: it has the necessary `next()` method and remembers the current iteration progress in `this.current`. Shorter? Yes. And sometimes that's fine too.
 
 The downside is that now it's impossible to have two `for..of` loops running over the object simultaneously: they'll share the iteration state, because there's only one iterator -- the object itself. But two parallel for-ofs is a rare thing, even in async scenarios.
 
@@ -115,7 +112,6 @@ There are no limitations on `next`, it can return more and more values, that's n
 Of course, the `for..of` loop over such an iterable would be endless. But we can always stop it using `break`.
 ```
 
-
 ## String is iterable
 
 Arrays and strings are most widely used built-in iterables.
@@ -125,16 +121,16 @@ For a string, `for..of` loops over its characters:
 ```js run
 for (let char of "test") {
   // triggers 4 times: once for each character
-  alert( char ); // t, then e, then s, then t
+  alert(char); // t, then e, then s, then t
 }
 ```
 
 And it works correctly with surrogate pairs!
 
 ```js run
-let str = '𝒳😂';
+let str = "𝒳😂";
 for (let char of str) {
-    alert( char ); // 𝒳, and then 😂
+  alert(char); // 𝒳, and then 😂
 }
 ```
 
@@ -167,8 +163,8 @@ That is rarely needed, but gives us more control over the process than `for..of`
 
 Two official terms look similar, but are very different. Please make sure you understand them well to avoid the confusion.
 
-- *Iterables* are objects that implement the `Symbol.iterator` method, as described above.
-- *Array-likes* are objects that have indexes and `length`, so they look like arrays.
+- _Iterables_ are objects that implement the `Symbol.iterator` method, as described above.
+- _Array-likes_ are objects that have indexes and `length`, so they look like arrays.
 
 When we use JavaScript for practical tasks in a browser or any other environment, we may meet objects that are iterables or array-likes, or both.
 
@@ -193,7 +189,7 @@ for (let item of arrayLike) {}
 */!*
 ```
 
-Both iterables and array-likes are usually *not arrays*, they don't have `push`, `pop` etc. That's rather inconvenient if we have such an object and want to work with it as with an array. E.g. we would like to work with `range` using array methods. How to achieve that?
+Both iterables and array-likes are usually _not arrays_, they don't have `push`, `pop` etc. That's rather inconvenient if we have such an object and want to work with it as with an array. E.g. we would like to work with `range` using array methods. How to achieve that?
 
 ## Array.from
 
@@ -225,8 +221,9 @@ alert(arr); // 1,2,3,4,5 (array toString conversion works)
 ```
 
 The full syntax for `Array.from` also allows us to provide an optional "mapping" function:
+
 ```js
-Array.from(obj[, mapFn, thisArg])
+Array.from(obj, mapFn, thisArg);
 ```
 
 The optional second argument `mapFn` can be a function that will be applied to each element before adding it to the array, and `thisArg` allows us to set `this` for it.
@@ -237,7 +234,7 @@ For instance:
 // assuming that range is taken from the example above
 
 // square each number
-let arr = Array.from(range, num => num * num);
+let arr = Array.from(range, (num) => num * num);
 
 alert(arr); // 1,4,9,16,25
 ```
@@ -245,7 +242,7 @@ alert(arr); // 1,4,9,16,25
 Here we use `Array.from` to turn a string into an array of characters:
 
 ```js run
-let str = '𝒳😂';
+let str = "𝒳😂";
 
 // splits str into array of characters
 let chars = Array.from(str);
@@ -260,7 +257,7 @@ Unlike `str.split`, it relies on the iterable nature of the string and so, just 
 Technically here it does the same as:
 
 ```js run
-let str = '𝒳😂';
+let str = "𝒳😂";
 
 let chars = []; // Array.from internally does the same loop
 for (let char of str) {
@@ -276,32 +273,30 @@ We can even build surrogate-aware `slice` on it:
 
 ```js run
 function slice(str, start, end) {
-  return Array.from(str).slice(start, end).join('');
+  return Array.from(str).slice(start, end).join("");
 }
 
-let str = '𝒳😂𩷶';
+let str = "𝒳😂𩷶";
 
-alert( slice(str, 1, 3) ); // 😂𩷶
+alert(slice(str, 1, 3)); // 😂𩷶
 
 // the native method does not support surrogate pairs
-alert( str.slice(1, 3) ); // garbage (two pieces from different surrogate pairs)
+alert(str.slice(1, 3)); // garbage (two pieces from different surrogate pairs)
 ```
-
 
 ## Summary
 
-Objects that can be used in `for..of` are called *iterable*.
+Objects that can be used in `for..of` are called _iterable_.
 
 - Technically, iterables must implement the method named `Symbol.iterator`.
-    - The result of `obj[Symbol.iterator]()` is called an *iterator*. It handles further iteration process.
-    - An iterator must have the method named `next()` that returns an object `{done: Boolean, value: any}`, here `done:true` denotes the end of the iteration process, otherwise the `value` is the next value.
+  - The result of `obj[Symbol.iterator]()` is called an _iterator_. It handles further iteration process.
+  - An iterator must have the method named `next()` that returns an object `{done: Boolean, value: any}`, here `done:true` denotes the end of the iteration process, otherwise the `value` is the next value.
 - The `Symbol.iterator` method is called automatically by `for..of`, but we also can do it directly.
 - Built-in iterables like strings or arrays, also implement `Symbol.iterator`.
 - String iterator knows about surrogate pairs.
 
-
-Objects that have indexed properties and `length` are called *array-like*. Such objects may also have other properties and methods, but lack the built-in methods of arrays.
+Objects that have indexed properties and `length` are called _array-like_. Such objects may also have other properties and methods, but lack the built-in methods of arrays.
 
 If we look inside the specification -- we'll see that most built-in methods assume that they work with iterables or array-likes instead of "real" arrays, because that's more abstract.
 
-`Array.from(obj[, mapFn, thisArg])` makes a real `Array` from an iterable or array-like `obj`, and we can then use array methods on it. The optional arguments `mapFn` and `thisArg` allow us to apply a function to each item.
+`Array.from(obj, mapFn, thisArg)` makes a real `Array` from an iterable or array-like `obj`, and we can then use array methods on it. The optional arguments `mapFn` and `thisArg` allow us to apply a function to each item.

--- a/1-js/05-data-types/06-iterable/article.md
+++ b/1-js/05-data-types/06-iterable/article.md
@@ -1,10 +1,12 @@
+
 # Iterables
 
-_Iterable_ objects are a generalization of arrays. That's a concept that allows us to make any object useable in a `for..of` loop.
+*Iterable* objects are a generalization of arrays. That's a concept that allows us to make any object useable in a `for..of` loop.
 
 Of course, Arrays are iterable. But there are many other built-in objects, that are iterable as well. For instance, strings are also iterable.
 
 If an object isn't technically an array, but represents a collection (list, set) of something, then `for..of` is a great syntax to loop over it, so let's see how to make it work.
+
 
 ## Symbol.iterator
 
@@ -17,7 +19,7 @@ Like a `range` object that represents an interval of numbers:
 ```js
 let range = {
   from: 1,
-  to: 5,
+  to: 5
 };
 
 // We want the for..of to work:
@@ -26,8 +28,8 @@ let range = {
 
 To make the `range` object iterable (and thus let `for..of` work) we need to add a method to the object named `Symbol.iterator` (a special built-in symbol just for that).
 
-1. When `for..of` starts, it calls that method once (or errors if not found). The method must return an _iterator_ -- an object with the method `next`.
-2. Onward, `for..of` works _only with that returned object_.
+1. When `for..of` starts, it calls that method once (or errors if not found). The method must return an *iterator* -- an object with the method `next`.
+2. Onward, `for..of` works *only with that returned object*.
 3. When `for..of` wants the next value, it calls `next()` on that object.
 4. The result of `next()` must have the form `{done: Boolean, value: any}`, where `done=true` means that the loop is finished, otherwise `value` is the next value.
 
@@ -36,11 +38,12 @@ Here's the full implementation for `range` with remarks:
 ```js run
 let range = {
   from: 1,
-  to: 5,
+  to: 5
 };
 
 // 1. call to for..of initially calls this
-range[Symbol.iterator] = function () {
+range[Symbol.iterator] = function() {
+
   // ...it returns the iterator object:
   // 2. Onward, for..of works only with the iterator object below, asking it for next values
   return {
@@ -55,7 +58,7 @@ range[Symbol.iterator] = function () {
       } else {
         return { done: true };
       }
-    },
+    }
   };
 };
 
@@ -92,7 +95,7 @@ let range = {
     } else {
       return { done: true };
     }
-  },
+  }
 };
 
 for (let num of range) {
@@ -100,7 +103,7 @@ for (let num of range) {
 }
 ```
 
-Now `range[Symbol.iterator]()` returns the `range` object itself: it has the necessary `next()` method and remembers the current iteration progress in `this.current`. Shorter? Yes. And sometimes that's fine too.
+Now `range[Symbol.iterator]()` returns the `range` object itself:  it has the necessary `next()` method and remembers the current iteration progress in `this.current`. Shorter? Yes. And sometimes that's fine too.
 
 The downside is that now it's impossible to have two `for..of` loops running over the object simultaneously: they'll share the iteration state, because there's only one iterator -- the object itself. But two parallel for-ofs is a rare thing, even in async scenarios.
 
@@ -112,6 +115,7 @@ There are no limitations on `next`, it can return more and more values, that's n
 Of course, the `for..of` loop over such an iterable would be endless. But we can always stop it using `break`.
 ```
 
+
 ## String is iterable
 
 Arrays and strings are most widely used built-in iterables.
@@ -121,16 +125,16 @@ For a string, `for..of` loops over its characters:
 ```js run
 for (let char of "test") {
   // triggers 4 times: once for each character
-  alert(char); // t, then e, then s, then t
+  alert( char ); // t, then e, then s, then t
 }
 ```
 
 And it works correctly with surrogate pairs!
 
 ```js run
-let str = "𝒳😂";
+let str = '𝒳😂';
 for (let char of str) {
-  alert(char); // 𝒳, and then 😂
+    alert( char ); // 𝒳, and then 😂
 }
 ```
 
@@ -163,8 +167,8 @@ That is rarely needed, but gives us more control over the process than `for..of`
 
 Two official terms look similar, but are very different. Please make sure you understand them well to avoid the confusion.
 
-- _Iterables_ are objects that implement the `Symbol.iterator` method, as described above.
-- _Array-likes_ are objects that have indexes and `length`, so they look like arrays.
+- *Iterables* are objects that implement the `Symbol.iterator` method, as described above.
+- *Array-likes* are objects that have indexes and `length`, so they look like arrays.
 
 When we use JavaScript for practical tasks in a browser or any other environment, we may meet objects that are iterables or array-likes, or both.
 
@@ -189,7 +193,7 @@ for (let item of arrayLike) {}
 */!*
 ```
 
-Both iterables and array-likes are usually _not arrays_, they don't have `push`, `pop` etc. That's rather inconvenient if we have such an object and want to work with it as with an array. E.g. we would like to work with `range` using array methods. How to achieve that?
+Both iterables and array-likes are usually *not arrays*, they don't have `push`, `pop` etc. That's rather inconvenient if we have such an object and want to work with it as with an array. E.g. we would like to work with `range` using array methods. How to achieve that?
 
 ## Array.from
 
@@ -221,9 +225,8 @@ alert(arr); // 1,2,3,4,5 (array toString conversion works)
 ```
 
 The full syntax for `Array.from` also allows us to provide an optional "mapping" function:
-
 ```js
-Array.from(obj, mapFn, thisArg);
+Array.from(obj, mapFn, thisArg)
 ```
 
 The optional second argument `mapFn` can be a function that will be applied to each element before adding it to the array, and `thisArg` allows us to set `this` for it.
@@ -234,7 +237,7 @@ For instance:
 // assuming that range is taken from the example above
 
 // square each number
-let arr = Array.from(range, (num) => num * num);
+let arr = Array.from(range, num => num * num);
 
 alert(arr); // 1,4,9,16,25
 ```
@@ -242,7 +245,7 @@ alert(arr); // 1,4,9,16,25
 Here we use `Array.from` to turn a string into an array of characters:
 
 ```js run
-let str = "𝒳😂";
+let str = '𝒳😂';
 
 // splits str into array of characters
 let chars = Array.from(str);
@@ -257,7 +260,7 @@ Unlike `str.split`, it relies on the iterable nature of the string and so, just 
 Technically here it does the same as:
 
 ```js run
-let str = "𝒳😂";
+let str = '𝒳😂';
 
 let chars = []; // Array.from internally does the same loop
 for (let char of str) {
@@ -273,29 +276,31 @@ We can even build surrogate-aware `slice` on it:
 
 ```js run
 function slice(str, start, end) {
-  return Array.from(str).slice(start, end).join("");
+  return Array.from(str).slice(start, end).join('');
 }
 
-let str = "𝒳😂𩷶";
+let str = '𝒳😂𩷶';
 
-alert(slice(str, 1, 3)); // 😂𩷶
+alert( slice(str, 1, 3) ); // 😂𩷶
 
 // the native method does not support surrogate pairs
-alert(str.slice(1, 3)); // garbage (two pieces from different surrogate pairs)
+alert( str.slice(1, 3) ); // garbage (two pieces from different surrogate pairs)
 ```
+
 
 ## Summary
 
-Objects that can be used in `for..of` are called _iterable_.
+Objects that can be used in `for..of` are called *iterable*.
 
 - Technically, iterables must implement the method named `Symbol.iterator`.
-  - The result of `obj[Symbol.iterator]()` is called an _iterator_. It handles further iteration process.
-  - An iterator must have the method named `next()` that returns an object `{done: Boolean, value: any}`, here `done:true` denotes the end of the iteration process, otherwise the `value` is the next value.
+    - The result of `obj[Symbol.iterator]()` is called an *iterator*. It handles further iteration process.
+    - An iterator must have the method named `next()` that returns an object `{done: Boolean, value: any}`, here `done:true` denotes the end of the iteration process, otherwise the `value` is the next value.
 - The `Symbol.iterator` method is called automatically by `for..of`, but we also can do it directly.
 - Built-in iterables like strings or arrays, also implement `Symbol.iterator`.
 - String iterator knows about surrogate pairs.
 
-Objects that have indexed properties and `length` are called _array-like_. Such objects may also have other properties and methods, but lack the built-in methods of arrays.
+
+Objects that have indexed properties and `length` are called *array-like*. Such objects may also have other properties and methods, but lack the built-in methods of arrays.
 
 If we look inside the specification -- we'll see that most built-in methods assume that they work with iterables or array-likes instead of "real" arrays, because that's more abstract.
 


### PR DESCRIPTION
I was reading 1-js/05-data-types/06-iterable and I came across:
`Array.from(obj[, mapFn, thisArg])`

It looks like a typo. I think it should be:
`Array.from(obj, mapFn, thisArg)`