### PR TITLE
Improved phrasing and clarity of the number of polyfill libraries.

### DIFF
--- a/1-js/03-code-quality/06-polyfills/article.md
+++ b/1-js/03-code-quality/06-polyfills/article.md
@@ -71,8 +71,7 @@ if (!Math.trunc) { // if no such function
 
 JavaScript is a highly dynamic language. Scripts may add/modify any function, even built-in ones.
 
-Two interesting polyfill libraries are:
-- [core js](https://github.com/zloirock/core-js) that supports a lot, allows to include only needed features.
+An interesting polyfill library is [core-js](https://github.com/zloirock/core-js). It provides extensive support and allows for adding only the needed features.
 
 
 ## Summary


### PR DESCRIPTION
# The Issue
The current article [states](https://javascript.info/polyfills#polyfills) that:

> Two interesting polyfill libraries are:
> - [core js](https://github.com/zloirock/core-js) that supports a lot, allows to include only needed features.

# Suggested Fix
Rewrite it in two sentences:

> An interesting polyfill library is [core-js](https://github.com/zloirock/core-js). It provides extensive support and allows for adding only the needed features.

(Please note that the name of the library includes a hyphen—according to their convention.)

# Corresponding Open Issues and Pull Requests
1. #3784
2. #3762
3. #3757
4. #3755