### PR TITLE
fix(example): update fetch example to demonstrate "Cross-Origin Reque…

### DIFF
--- a/5-network/05-fetch-crossorigin/article.md
+++ b/5-network/05-fetch-crossorigin/article.md
@@ -6,7 +6,7 @@ For instance, let's try fetching `http://example.com`:
 
 ```js run async
 try {
-  await fetch('http://example.com');
+  await fetch('https://example.com');
 } catch(err) {
   alert(err); // Failed to fetch
 }


### PR DESCRIPTION
…st Blocked" error

- Replaced `http` with `https` in the example URL to trigger "Cross-Origin Request Blocked."