### PR TITLE
fix: Unclosed comment block in CSS

### DIFF
--- a/2-ui/2-events/01-introduction-browser-events/07-carousel/source.view/style.css
+++ b/2-ui/2-events/01-introduction-browser-events/07-carousel/source.view/style.css
@@ -34,5 +34,5 @@ ul img {
 }
 
 ul li {
-  display: inline-block; /* removes extra space between list items
+  display: inline-block; /* removes extra space between list items */
 }


### PR DESCRIPTION
Fixed unclosed comment block in CSS file '2-ui\2-events\01-introduction-browser-events\07-carousel\source.view'
Found while translating the page for the french version