### PR TITLE
Update WeakMap and WeakSet: object reference is stored in array

### DIFF
--- a/1-js/05-data-types/08-weakmap-weakset/article.md
+++ b/1-js/05-data-types/08-weakmap-weakset/article.md
@@ -32,7 +32,7 @@ let array = [ john ];
 john = null; // overwrite the reference
 
 *!*
-// the object previously referenced by john is stored inside the array
+// the object previously referenced by john is still referenced by the first element in the array
 // therefore it won't be garbage-collected
 // we can get it as array[0]
 */!*


### PR DESCRIPTION
Earlier sentence:
> the object previously referenced by john is stored inside the array

But the object itself is not stored in the array. Its reference gets stored in the array.

Updated sentence:  
> the object previously referenced by john is still referenced by the first element in the array