### PR TITLE
replace args by params fix issue #3849 

### DIFF
--- a/1-js/02-first-steps/17-arrow-functions-basics/article.md
+++ b/1-js/02-first-steps/17-arrow-functions-basics/article.md
@@ -8,7 +8,7 @@ It's called "arrow functions", because it looks like this:
 let func = (arg1, arg2, ..., argN) => expression;
 ```
 
-This creates a function `func` that accepts arguments `arg1..argN`, then evaluates the `expression` on the right side with their use and returns its result.
+This creates a function `func` with parameters `arg1..argN`, then evaluates the `expression` on the right side with their use and returns its result.
 
 In other words, it's the shorter version of:
 
@@ -33,9 +33,9 @@ let sum = function(a, b) {
 alert( sum(1, 2) ); // 3
 ```
 
-As you can see, `(a, b) => a + b` means a function that accepts two arguments named `a` and `b`. Upon the execution, it evaluates the expression `a + b` and returns the result.
+As you can see, `(a, b) => a + b` means a function that defines two parameters named `a` and `b`. Upon the execution, it evaluates the expression `a + b` and returns the result.
 
-- If we have only one argument, then parentheses around parameters can be omitted, making that even shorter.
+- If we have only one parameter, then parentheses around it can be omitted, making that even shorter.
 
     For example:
 
@@ -48,7 +48,7 @@ As you can see, `(a, b) => a + b` means a function that accepts two arguments na
     alert( double(3) ); // 6
     ```
 
-- If there are no arguments, parentheses are empty, but they must be present:
+- If there are no parameters, parentheses are empty, but they must be present:
 
     ```js run
     let sayHi = () => alert("Hello!");


### PR DESCRIPTION
Fixes issue #3849
param is the correct word when declaring a function

line 11
"accepts 2 args" is not wrong, but "with 2 params" we emphasize we are declaring the functions and params

In the summary, 
"args" is ok because it talks about what is expecting. It could be rephrased but I dont think it's neccesary or clearer
