### PR TITLE
Link to the "falsy" term issue #3851

### DIFF
--- a/1-js/02-first-steps/10-ifelse/article.md
+++ b/1-js/02-first-steps/10-ifelse/article.md
@@ -31,7 +31,7 @@ if (year == 2015) {
 
 We recommend wrapping your code block with curly braces `{}` every time you use an `if` statement, even if there is only one statement to execute. Doing so improves readability.
 
-## Boolean conversion [#ifelse-boolean-conversion]
+## Boolean conversion [#boolean-conversion]
 
 The `if (…)` statement evaluates the expression in its parentheses and converts the result to a boolean.
 

--- a/1-js/02-first-steps/10-ifelse/article.md
+++ b/1-js/02-first-steps/10-ifelse/article.md
@@ -31,7 +31,7 @@ if (year == 2015) {
 
 We recommend wrapping your code block with curly braces `{}` every time you use an `if` statement, even if there is only one statement to execute. Doing so improves readability.
 
-## Boolean conversion
+## Boolean conversion [#ifelse-boolean-conversion]
 
 The `if (…)` statement evaluates the expression in its parentheses and converts the result to a boolean.
 

--- a/1-js/02-first-steps/11-logical-operators/article.md
+++ b/1-js/02-first-steps/11-logical-operators/article.md
@@ -29,7 +29,7 @@ alert( false || false ); // false
 
 As we can see, the result is always `true` except for the case when both operands are `false`.
 
-If an operand is not a boolean, it's converted to a boolean for the evaluation.
+If an operand is not a boolean, it's converted to a boolean for the evaluation. This is part of the familiar truthy/falsy concept <info:#ifelse-boolean-conversion>.
 
 For instance, the number `1` is treated as `true`, the number `0` as `false`:
 

--- a/1-js/02-first-steps/11-logical-operators/article.md
+++ b/1-js/02-first-steps/11-logical-operators/article.md
@@ -29,7 +29,7 @@ alert( false || false ); // false
 
 As we can see, the result is always `true` except for the case when both operands are `false`.
 
-If an operand is not a boolean, it's converted to a boolean for the evaluation. This is part of the familiar truthy/falsy concept <info:#ifelse-boolean-conversion>.
+If an operand is not a boolean, it's converted to a boolean for the evaluation. This is part of the familiar [truthy/falsy](info:ifelse#boolean-conversion) concept.
 
 For instance, the number `1` is treated as `true`, the number `0` as `false`:
 


### PR DESCRIPTION
Logical operators use falsy/truthy term
There is an explanation in the previous chapter, but it's easy to miss.
Just added a link to it.