### PR TITLE
Fix incorrect use of "bytes" when referring to Unicode code points

### DIFF
--- a/1-js/99-js-misc/06-unicode/article.md
+++ b/1-js/99-js-misc/06-unicode/article.md
@@ -35,7 +35,7 @@ JavaScript allows us to insert a character into a string by specifying its hexad
 
 - `\u{X…XXXXXX}`
 
-    `X…XXXXXX` must be a hexadecimal value of 1 to 6 bytes between `0` and `10FFFF` (the highest code point defined by Unicode). This notation allows us to easily represent all existing Unicode characters.
+    `X…XXXXXX` must be a hexadecimal value between `0` and `10FFFF` (the highest code point defined by Unicode), consisting of 1 to 6 hexadecimal digits. This notation allows us to easily represent all existing Unicode characters.
 
     ```js run
     alert( "\u{20331}" ); // 佫, a rare Chinese character (long Unicode)


### PR DESCRIPTION
This PR corrects the phrase "1 to 6 bytes" to "1 to 6 hexadecimal digits" in the Unicode code point description. Unicode code points range from `0x0` to `0x10FFFF`, which requires up to 6 hex digits (21 bits), not 6 bytes. 