### PR TITLE
Improved arrow function arguments example

### DIFF
--- a/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
+++ b/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
@@ -110,12 +110,17 @@ If we access the `arguments` object from an arrow function, it takes them from t
 Here's an example:
 
 ```js run
-function f() {
-  let showArg = () => alert(arguments[0]);
-  showArg();
+function f(){
+
+    alert(arguments[0]);  
+    let arrow = msg => {
+        alert(msg); 
+        alert(arguments[0]);    // arguments stores all the arguments passed to a function so this arguments must store the parameters that are passed while calling arrow function right? 
+    }
+    arrow(arguments[1]);
 }
 
-f(1); // 1
+f(1, "Hii");    // 1   Hii   1
 ```
 
 As we remember, arrow functions don't have their own `this`. Now we know they don't have the special `arguments` object either.


### PR DESCRIPTION
The updated example better demonstrates how arguments behaves inside arrow functions. In the previous example, the arrow function was invoked without passing its own parameters, so it wasn’t obvious that arguments inside an arrow function refers to the arguments of the outer normal function.

In the new example, we explicitly pass a parameter ("Hii") to the arrow function, and also log arguments[0] inside it. This makes it clear that arguments[0] is still taken from the outer function (1) and not from the arrow function’s own parameter list, illustrating the lexical binding behavior of arguments in arrow functions.