### PR TITLE
Fix: Javascript's earlier names

### DIFF
--- a/1-js/01-getting-started/1-intro/article.md
+++ b/1-js/01-getting-started/1-intro/article.md
@@ -13,7 +13,7 @@ Scripts are provided and executed as plain text. They don't need special prepara
 In this aspect, JavaScript is very different from another language called [Java](https://en.wikipedia.org/wiki/Java_(programming_language)).
 
 ```smart header="Why is it called <u>Java</u>Script?"
-When JavaScript was created, it initially had another name: "LiveScript". But Java was very popular at that time, so it was decided that positioning a new language as a "younger brother" of Java would help.
+When JavaScript was created, it initially had another name: "Mocha", which was changed to "LiveScript" later. But Java was very popular at that time, so it was decided that positioning a new language as a "younger brother" of Java would help.
 
 But as it evolved, JavaScript became a fully independent language with its own specification called [ECMAScript](http://en.wikipedia.org/wiki/ECMAScript), and now it has no relation to Java at all.
 ```


### PR DESCRIPTION
Initially, Javscript was called "Mocha", then changed to "LiveScript" before finally being named JavaScript. 