### PR TITLE
Fix Generator Seed Consistency Test

### DIFF
--- a/1-js/12-generators-iterators/1-generators/01-pseudo-random-generator/_js.view/test.js
+++ b/1-js/12-generators-iterators/1-generators/01-pseudo-random-generator/_js.view/test.js
@@ -13,9 +13,13 @@ describe("pseudoRandom", function() {
     let generator1 = pseudoRandom(123);
     let generator2 = pseudoRandom(123);
 
+    let generator3 = pseudoRandom(1234);
+    let generator4 = pseudoRandom(12345);
+
     assert.deepEqual(generator1.next(), generator2.next());
     assert.deepEqual(generator1.next(), generator2.next());
     assert.deepEqual(generator1.next(), generator2.next());
+    assert.notDeepEqual(generator3.next(), generator4.next());
   });
 
 });


### PR DESCRIPTION
If you use a static seed in your code, all tests will pass, because technically the seed is the same, however, the input changed so it shouldn't be the same.

Example of a static seed:
<img width="362" height="163" alt="Screenshot 2025-09-06 at 7 25 12 AM" src="https://github.com/user-attachments/assets/5486fe4b-c36a-4ba3-99da-b3515f66cbff" />

And here's the actual seed being used:
<img width="456" height="157" alt="Screenshot 2025-09-06 at 7 25 34 AM" src="https://github.com/user-attachments/assets/06b043a0-46a5-4bb7-ac23-f490f17c9de5" />

With the current code, both solutions will pass even if the input changes.