### PR TITLE
fix: bitwise/logical NOT correction

### DIFF
--- a/1-js/06-advanced-functions/04-var/article.md
+++ b/1-js/06-advanced-functions/04-var/article.md
@@ -265,7 +265,7 @@ There exist other ways besides parentheses to tell JavaScript that we mean a Fun
 }()*!*)*/!*;
 
 *!*!*/!*function() {
-  alert("Bitwise NOT operator starts the expression");
+  alert("Logical NOT operator starts the expression");
 }();
 
 *!*+*/!*function() {


### PR DESCRIPTION
In 1.6.4 "The old 'var' ", an example in the IIFE section states:

> !function() {
  alert("Bitwise NOT operator starts the expression");
}();

although `!` represents the logical NOT operator rather than the bitwise NOT operator.