### PR TITLE
fix: correct substring method in string article.md en

### DIFF
--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -326,7 +326,7 @@ alert( "Wid*!*get*/!*".endsWith("get") ); // true, "Widget" ends with "get"
 
 ## Getting a substring
 
-There are 3 methods in JavaScript to get a substring: `substring`, `substr` and `slice`.
+There are 3 methods in JavaScript to get a substring: `slice`, `substring` and `substr`.
 
 `str.slice(start [, end])`
 : Returns the part of the string from `start` to (but not including) `end`.
@@ -356,9 +356,7 @@ There are 3 methods in JavaScript to get a substring: `substring`, `substr` and 
     ```
 
 `str.substring(start [, end])`
-: Returns the part of the string *between* `start` and `end` (not including `end`).
-
-    This is almost the same as `slice`, but it allows `start` to be greater than `end` (in this case it simply swaps `start` and `end` values).
+: Like `slice`, returns the part of the string from `start` to (but not including) `end`; however, it allows `start` to be greater than `end` (in this case it simply swaps `start` and `end` values).
 
     For instance:
 
@@ -400,8 +398,8 @@ Let's recap these methods to avoid any confusion:
 
 | method | selects... | negatives |
 |--------|-----------|-----------|
-| `slice(start, end)` | from `start` to `end` (not including `end`) | allows negatives |
-| `substring(start, end)` | between `start` and `end` (not including `end`)| negative values mean `0` |
+| `slice(start, end)` | from `start` to (but not including) `end` | allows negatives |
+| `substring(start, end)` | from `start` to (but not including) `end` | negative values mean `0` |
 | `substr(start, length)` | from `start` get `length` characters | allows negative `start` |
 
 ```smart header="Which one to choose?"


### PR DESCRIPTION
### Getting a substring
The word _"between"_ is not suitable for describing this method - its meaning is precisely: _"to fall between two stools"_.
If this mistake was based on MDN-article incorrect [ru-translation](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/String/substring), then it has already been fixed there by [this](https://github.com/mdn/translated-content/pull/29335) PR,
in accordance with the [en-original](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring).

<img width="1136" height="263" alt="image" src="https://github.com/user-attachments/assets/6a2b6221-4fc7-4ac3-864e-5ab1b87ad0f6" />
