### PR TITLE
fix(switch): correct value in example

### DIFF
--- a/1-js/02-first-steps/14-switch/article.md
+++ b/1-js/02-first-steps/14-switch/article.md
@@ -117,7 +117,7 @@ Several variants of `case` which share the same code can be grouped.
 For example, if we want the same code to run for `case 3` and `case 5`:
 
 ```js run no-beautify
-let a = 3;
+let a = 2 + 2;
 
 switch (a) {
   case 4:


### PR DESCRIPTION
In the 'switch' article, the code example for grouping cases was using an incorrect value for the variable `a`. This caused the example to not follow the intended logic of demonstrating the `case 4:` execution.

This PR corrects the value of `a` from `3` to `2 + 2`, aligning the English version with the corrected Portuguese translation and ensuring the example works as described.