### PR TITLE
clarify wording about null and undefined equality in JS

### DIFF
--- a/1-js/02-first-steps/09-comparison/article.md
+++ b/1-js/02-first-steps/09-comparison/article.md
@@ -212,5 +212,5 @@ Why did we go over these examples? Should we remember these peculiarities all th
 - Comparison operators return a boolean value.
 - Strings are compared letter-by-letter in the "dictionary" order.
 - When values of different types are compared, they get converted to numbers (with the exclusion of a strict equality check).
-- The values `null` and `undefined` are equal `==` to themselves to and each other, but do not equal any other value.
+- The values `null` and `undefined` are equal `==` to themselves and each other, but do not equal any other value.
 - Be careful when using comparisons like `>` or `<` with variables that can occasionally be `null/undefined`. Checking for `null/undefined` separately is a good idea.


### PR DESCRIPTION
Updated the explanation of JavaScript’s loose equality to accurately state that null and undefined are equal to themselves and to each other (==), but not equal to any other value. The previous wording was ambiguous about whether “each other” included self-equality.