### PR TITLE
Array Methods: Remove requirement for equal probability from array shuffle

### DIFF
--- a/1-js/05-data-types/05-array-methods/9-shuffle/task.md
+++ b/1-js/05-data-types/05-array-methods/9-shuffle/task.md
@@ -21,5 +21,3 @@ shuffle(arr);
 // arr = [3, 1, 2]
 // ...
 ```
-
-All element orders should have an equal probability. For instance, `[1,2,3]` can be reordered as `[1,2,3]` or `[1,3,2]` or `[3,1,2]` etc, with equal probability of each case.


### PR DESCRIPTION
Given the scope and intent of the [array methods lesson](https://javascript.info/array-methods) and the expected knowledge level of learners going through this lesson, I don't believe the "Shuffle an array" task should instruct to make each permutation of equal probability. Successfully achieving that requires that either someone happens to already know a shuffling algorithm like Fisher-Yates, or understands why nuances with `Array.prototype.sort()` would lead to permutation bias.

I think it's more pedagogically appropriate to simply omit that requirement from the instructions. That requirement won't likely change much about how many learners would do things, but risks sending someone down a rabbit hole of stuff out of the scope of practising working with arrays and array methods.

The solution can stay as is -  the explanation is good and makes sense to introduce the permutation bias concept there, just not as an actual requirement for the task.

In various learning communities I take part in, this is a very common pain point and rabbit hole I see learners go down when trying to solve it (i.e. not a rabbit hole they go down after reading the explanation).