### PR TITLE
fix: correct definition of spread syntax in generators article.md en

### DIFF
--- a/1-js/12-generators-iterators/1-generators/article.md
+++ b/1-js/12-generators-iterators/1-generators/article.md
@@ -154,7 +154,7 @@ let sequence = [0, ...generateSequence()];
 alert(sequence); // 0, 1, 2, 3
 ```
 
-In the code above, `...generateSequence()` turns the iterable generator object into an array of items (read more about the spread syntax in the chapter [](info:rest-parameters-spread#spread-syntax))
+In the code above, `...generateSequence()` "expands" the iterable generator object into a list of values (read more about the spread syntax in the chapter [](info:rest-parameters-spread#spread-syntax))
 
 ## Using generators for iterables
 


### PR DESCRIPTION
### Generators
Spread syntax does not turn the iterable object into an array of items,
but in this article example, when used in a literal array declaration,
it adds the expanded list of generator values ​​to that array✅