### PR TITLE
Docs: clarify typeof alert behavior in non-browser environments

### DIFF
--- a/1-js/02-first-steps/05-types/article.md
+++ b/1-js/02-first-steps/05-types/article.md
@@ -243,7 +243,7 @@ typeof null // "object"  (2)
 */!*
 
 *!*
-typeof alert // "function"  (3)
+typeof alert // "function" (Browser Console)  (3)
 */!*
 ```
 


### PR DESCRIPTION
Clarified the output of typeof alert in the browser console.

Change
```js
typeof alert // "function" (Browser Console)  (3)

```

This PR closes #3926 