### PR TITLE
fix: clarify point in events-change-input article.md en

### DIFF
--- a/2-ui/4-forms-controls/3-events-change-input/article.md
+++ b/2-ui/4-forms-controls/3-events-change-input/article.md
@@ -87,7 +87,7 @@ It's possible to copy/paste not just text, but everything. For instance, we can 
 
 That's because `clipboardData` implements `DataTransfer` interface, commonly used for drag'n'drop and copy/pasting. It's a bit beyond our scope now, but you can find its methods in the [DataTransfer specification](https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface).
 
-Also, there's an additional asynchronous API of accessing the clipboard: `navigator.clipboard`. More about it in the specification [Clipboard API and events](https://www.w3.org/TR/clipboard-apis/), [not supported by Firefox](https://caniuse.com/async-clipboard).
+Also, there's an additional asynchronous API of accessing the clipboard: `navigator.clipboard`. More about it in the specification [Clipboard API and events](https://www.w3.org/TR/clipboard-apis/).
 
 ### Safety restrictions
 
@@ -95,7 +95,7 @@ The clipboard is a "global" OS-level thing. A user may switch between various ap
 
 So most browsers allow seamless read/write access to the clipboard only in the scope of certain user actions, such as copying/pasting etc.
 
-It's forbidden to generate "custom" clipboard events with `dispatchEvent` in all browsers except Firefox. And even if we manage to dispatch such event, the specification clearly states that such "synthetic" events must not provide access to the clipboard.
+It's forbidden to generate "custom" clipboard events with `dispatchEvent`. And even if we manage to dispatch such event, the specification clearly states that such "synthetic" events must not provide access to the clipboard.
 
 Even if someone decides to save `event.clipboardData` in an event handler, and then access it later -- it won't work.
 
@@ -111,4 +111,4 @@ Data change events:
 |---------|----------|-------------|
 | `change`| A value was changed. | For text inputs triggers on focus loss. |
 | `input` | Fires whenever the value changes. | Triggers immediately unlike `change`. |
-| `cut/copy/paste` | Cut/copy/paste actions. | The action can be prevented. The `event.clipboardData` property gives access to the clipboard. All browsers except Firefox also support `navigator.clipboard`. |
+| `cut/copy/paste` | Cut/copy/paste actions. | The action can be prevented. The `event.clipboardData` property gives access to the clipboard. There’s also an asynchronous API -- `navigator.clipboard`. |


### PR DESCRIPTION
### Events: change, input, cut, copy, paste
Let it be more precise — this [event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event) is not only about text✅
P.S. Without focusing on Firefox.