### PR TITLE
fix: correct cross-window-communication article.md en

### DIFF
--- a/3-frames-and-windows/03-cross-window-communication/article.md
+++ b/3-frames-and-windows/03-cross-window-communication/article.md
@@ -51,7 +51,7 @@ For instance, let's try reading and writing to iframe from another origin:
     try {
       // ...but not to the document inside it
 *!*
-      let doc = iframe.contentDocument; // ERROR
+      let doc = iframe.contentDocument; // ...getting null
 */!*
     } catch(e) {
       alert(e); // Security Error (another origin)


### PR DESCRIPTION
### Cross-window communication

While [editing](https://github.com/javascript-tutorial/ru.javascript.info/pull/2123) the ru-version, it turned out that it's more natural in some respects.
It avoids the word `tag` – DOM entities are involved here,
sometimes it's more accurately stated that we're talking about objects,
the possibility of [getting](https://learn.javascript.ru/cross-window-communication#dostup-k-soderzhimomu-ifreyma) `error` or `null` with `another origin` is indicated, and so on.
But both couldn't avoid confusing newcomers' minds by misunderstanding the terms [event](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event) and its handler in [DOM property](https://javascript.info/introduction-browser-events#dom-property)
or providing unconfirmed information about [short syntax](https://developer.mozilla.org/en-US/docs/Web/API/Window/message_event#syntax) not working, etc.
So let's try to combine the best of each of these versions✅