### PR TITLE
fix: correct events related terms in fetch-api article.md en

### DIFF
--- a/5-network/06-fetch-api/article.md
+++ b/5-network/06-fetch-api/article.md
@@ -199,7 +199,7 @@ For example, we gather statistics on how the current visitor uses our page (mous
 
 When the visitor leaves our page -- we'd like to save the data to our server.
 
-We can use the `window.onunload` event for that:
+For that we can use the `unload` event on the `window` object:
 
 ```js run
 window.onunload = function() {
@@ -218,7 +218,7 @@ Normally, when a document is unloaded, all associated network requests are abort
 It has a few limitations:
 
 - We can't send megabytes: the body limit for `keepalive` requests is 64KB.
-    - If we need to gather a lot of statistics about the visit, we should send it out regularly in packets, so that there won't be a lot left for the last `onunload` request.
+    - If we need to gather a lot of statistics about the visit, we should send it out regularly in packets, so that by the time of the `unload` event there won't be much left to send.
     - This limit applies to all `keepalive` requests together. In other words, we can perform multiple `keepalive` requests in parallel, but the sum of their body lengths should not exceed 64KB.
 - We can't handle the server response if the document is unloaded. So in our example `fetch` will succeed due to `keepalive`, but subsequent functions won't work.
     - In most cases, such as sending out statistics, it's not a problem, as the server just accepts the data and usually sends an empty response to such requests.


### PR DESCRIPTION
### Fetch API
Let's not confuse newcomers' minds by misunderstanding the terms [event](https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event) and its handler in [DOM property](https://javascript.info/introduction-browser-events#dom-property)✅