### PR TITLE
fix: save eaten backslash in regexp-escaping article.md en

### DIFF
--- a/9-regular-expressions/07-regexp-escaping/article.md
+++ b/9-regular-expressions/07-regexp-escaping/article.md
@@ -65,7 +65,7 @@ The similar search in one of previous examples worked with `pattern:/\d\.\d/`, b
 
 The reason is that backslashes are "consumed" by a string. As we may recall, regular strings have their own special characters, such as `\n`, and a backslash is used for escaping.
 
-Here's how "\d\.\d" is perceived:
+Here's how "\d\\.\d" is perceived:
 
 ```js run
 alert("\d\.\d"); // d.d


### PR DESCRIPTION
### Escaping, special characters
Let's not lose the backslash while explain how not to lose it😎