### PR TITLE
Convert prompt inputs to numbers with unary plus

### DIFF
--- a/1-js/02-first-steps/15-function-basics/4-pow/solution.md
+++ b/1-js/02-first-steps/15-function-basics/4-pow/solution.md
@@ -10,8 +10,8 @@ function pow(x, n) {
   return result;
 }
 
-let x = prompt("x?", '');
-let n = prompt("n?", '');
+let x = +prompt("x?", '');
+let n = +prompt("n?", '');
 
 if (n < 1) {
   alert(`Power ${n} is not supported, use a positive integer`);


### PR DESCRIPTION
The task description says the function should take natural **numbers** only, but prompt() returns String, which we pass to pow().
It accidentally works because we use *= operator which performs implicit conversion.
But it is best to convert explicitly to improve code readability and align better with the task requirement.